### PR TITLE
fix: use StdioCollector.text property instead of text() call

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -386,7 +386,7 @@ Item {
     stdout: StdioCollector {
       onStreamFinished: {
         stateReadFallback.stop()
-        root.finishStateLoad(text())
+        root.finishStateLoad(text)
       }
     }
     // A bail-out still has to answer: `_stateLoaded` gates the whole service,


### PR DESCRIPTION
### Problem

`StdioCollector.text` is a **property** in current Quickshell, not a method.

`Service.qml:389` called it as a function:

```qml
root.finishStateLoad(text())
```

which throws on every shell start:

```
TypeError: Property 'text' of object StdioCollector(...) is not a function
  at Service.qml:389
```

The exception aborts the `onStreamFinished` handler for `stateReadProc`, so `finishStateLoad()` never runs via the normal path. The 250ms `stateReadFallback` timer then fires with an empty string, `applyStateText("")` returns false, and `~/.local/state/motion-wallpaper/state.json` is never applied. As a result the live wallpaper resets on every `omarchy restart shell` / login.

The persisted `videoPath` (e.g. `~/Videos/BMW JDM ... .webm`) stays in `state.json` but is ignored.

### Fix

```diff
-        root.finishStateLoad(text())
+        root.finishStateLoad(text)
```

Single-line change in `Service.qml` line 389.

### Verification

- Before fix: `journalctl --user` shows the TypeError every restart; `state.json` contains a valid `videoPath` but `motion-wallpaper status` reports no video after restart.
- After fix: no TypeError, `stateReadProc` loads `state.json`, selected video persists across `omarchy restart shell`:

```
status:     playing
video:      /home/ishanp/Videos/BMW JDM  4K Live Wallpaper ｜ Best Car Wallpaper for PC 2026.webm
screen:     all screens
auto-pause: on
```

### Notes

Only one occurrence of `.text()` exists in the plugin (`grep -rn "\.text()" *.qml`). No other collectors are affected.

Closes persistence bug reported after shell reload.