### PR TITLE
Add an adjustable playback speed

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -82,6 +82,10 @@ BarWidget {
     if (service) service.applySetOutput(name)
     else ipc("setOutput", name)
   }
+  function setSpeed(v) {
+    if (service) service.applySetSpeed(v)
+    else ipc("setSpeed", String(v))
+  }
   function setPauseOnFullscreen(on) {
     if (service) service.applySetPauseOnFullscreen(on ? "true" : "false")
     else ipc("setPauseOnFullscreen", on ? "true" : "false")

--- a/NOTES.md
+++ b/NOTES.md
@@ -47,7 +47,7 @@ Two sources, with a deliberate split:
   `Service.qml`'s `pluginConfig` falls back to `{}` when there is no entry, so
   every setting has a working default and the plugin runs without one.
 - **`~/.local/state/motion-wallpaper/state.json`** is the runtime truth. IPC
-  mutations (play/stop/toggle, screen, auto-pause) write it, so they survive a
+  mutations (play/stop/toggle, screen, auto-pause, speed) write it, so they survive a
   shell restart and a reboot. Editing the config entry re-seeds the state file.
 
 That split is why there is no autostart step: `play` means it returns after a
@@ -99,6 +99,18 @@ means what it says (and self-heals a stale `output` left by the CLI).
 click would flatten a per-screen setup — so the panel opens aimed at its own
 monitor instead. The bar mounts one widget per screen, so "its own monitor" is
 `button.QsWindow.window.screen.name`, surfaced as `screenName` on the widget.
+
+### Playback speed
+
+`playbackSpeed` on the service is bound to `playbackRate` on both players of
+every surface, so the A/B cross-fade pair stay in step. `safeSpeed()` clamps
+into `minSpeed`..`maxSpeed` and rounds to two decimals rather than snapping to
+a fixed set — a hand-edited `state.json` still cannot drive the decoder out of
+range, but any value inside it is honoured.
+
+The panel drives `playbackSpeed` directly while the slider is dragged and only
+calls `applySetSpeed` on release. A drag would otherwise write `state.json` on
+every pixel.
 
 ### Cross-fade on clip change
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -132,6 +132,32 @@ Item {
 
   function rescan() { scanProc.running = true }
 
+  // ---- playback speed ----
+  readonly property real minSpeed: panel.service ? Number(panel.service.minSpeed) : 0.25
+  readonly property real maxSpeed: panel.service ? Number(panel.service.maxSpeed) : 2.0
+  // Reference marks at the round speeds.
+  readonly property var speedMarks: [0.25, 0.5, 0.75, 1.0, 1.5, 2.0]
+
+  // < 0 unless a drag is in flight, so the readout follows the knob.
+  property real pendingSpeed: -1
+
+  readonly property real serviceSpeed: {
+    var v = panel.service ? Number(panel.service.playbackSpeed) : 1
+    return (isFinite(v) && v > 0) ? v : 1
+  }
+
+  readonly property real speedValue: panel.pendingSpeed >= 0 ? panel.pendingSpeed
+                                                             : panel.serviceSpeed
+
+  function roundSpeed(v) { return Math.round(Number(v) * 100) / 100 }
+
+  // Trailing zeros dropped: 1x, 0.5x, 0.66x - never 1.00x.
+  readonly property string speedLabel: {
+    var n = panel.roundSpeed(panel.speedValue)
+    var t = n.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")
+    return t + "x"
+  }
+
   Component.onCompleted: { rescan(); resetScope() }
 
   Connections {
@@ -297,6 +323,69 @@ Item {
       foreground: panel.fg
       checked: panel.service ? panel.service.pauseOnFullscreen === true : true
       onClicked: if (panel.widget) panel.widget.setPauseOnFullscreen(!checked)
+    }
+
+    // ---------- playback speed ----------
+    PanelSeparator { foreground: panel.fg }
+
+    PanelSectionHeader {
+      text: "SPEED"
+      foreground: panel.fg
+      fontFamily: panel.fontFamily
+    }
+
+    // Free over the whole range at 2-decimal precision; the ticks are just
+    // visual anchors at the round speeds.
+    Row {
+      width: parent.width
+      spacing: Style.spacing.controlGap
+
+      PanelSlider {
+        id: speedSlider
+        bar: panel.bar
+        width: parent.width - speedReadout.width - Style.spacing.controlGap
+        anchors.verticalCenter: parent.verticalCenter
+        minimum: panel.minSpeed
+        maximum: panel.maxSpeed
+        // PanelSlider ignores `step` and only quantises when `integer` is
+        // set, so the 2-decimal rounding is applied here.
+        integer: false
+        tickCount: panel.speedMarks.length
+        value: panel.speedValue
+        onMoved: function(v) {
+          panel.pendingSpeed = panel.roundSpeed(v)
+          // Live preview without writing state.json on every pixel; the
+          // release below is what persists.
+          if (panel.service) panel.service.playbackSpeed = panel.pendingSpeed
+        }
+        onReleased: function(v) {
+          var final = panel.roundSpeed(v)
+          panel.pendingSpeed = -1
+          if (panel.widget) panel.widget.setSpeed(final)
+        }
+      }
+
+      Text {
+        id: speedReadout
+        textFormat: Text.PlainText
+        anchors.verticalCenter: parent.verticalCenter
+        // Sized to the widest label so the slack goes back to the slider.
+        width: speedMetrics.width
+        horizontalAlignment: Text.AlignRight
+        text: panel.speedLabel
+        color: panel.fg
+        font.family: panel.fontFamily
+        font.pixelSize: Style.font.subtitle
+        font.bold: true
+      }
+
+      TextMetrics {
+        id: speedMetrics
+        font.family: panel.fontFamily
+        font.pixelSize: Style.font.subtitle
+        font.bold: true
+        text: "0.25x"
+      }
     }
 
     // ---------- video library ----------

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ motion-wallpaper toggle          # flip on/off
 motion-wallpaper pause           # pause / resume
 motion-wallpaper resume
 motion-wallpaper autopause off   # or: on
+motion-wallpaper speed 0.5       # playback speed, 0.25-2 (e.g. 1, 0.66)
 ```
 
 ### With a keybind
@@ -148,6 +149,14 @@ motion-wallpaper screens          # check what landed where
 ```
 
 Connector names come from `hyprctl monitors`. A monitor keeps its clip while it is unplugged, so it comes back to the right one; a monitor you have never set follows the default `videoPath` (and the legacy `motion-wallpaper screen <name|all>` targeting, which only applies to monitors with no clip of their own).
+
+### Playback speed
+
+A **SPEED** slider in the panel sets how fast the clip plays, anywhere from `0.25x` to `2x`. It is free rather than stepped — `0.66` and `0.99` are as reachable as `1` — with tick marks at the round speeds as anchors. Dragging previews live; letting go saves. The speed applies to every monitor.
+
+```bash
+motion-wallpaper speed 0.5
+```
 
 ### Persistence
 

--- a/Service.qml
+++ b/Service.qml
@@ -99,6 +99,15 @@ Item {
   }
 
   // Clamp a value to a sane path string, or "" if it cannot be one.
+  // Clamp into range and round to 2 decimals. Rounding keeps the persisted
+  // value tidy and stops a drag from writing 0.6600000000000001.
+  function safeSpeed(v) {
+    var n = Number(v)
+    if (!isFinite(n) || n <= 0) return 1.0
+    n = Math.max(root.minSpeed, Math.min(root.maxSpeed, n))
+    return Math.round(n * 100) / 100
+  }
+
   function safePath(v) {
     if (v === null || v === undefined) return ""
     var t = String(v)
@@ -120,6 +129,12 @@ Item {
   property string output: "all"
   property bool pauseOnFullscreen: true
   property bool manualPaused: false   // set by IPC pause(); cleared by resume()/play()
+  // Playback speed multiplier applied to every surface. Free anywhere in the
+  // range at 2-decimal precision - clamped rather than snapped, so a
+  // hand-edited state.json cannot drive the decoder somewhere absurd.
+  readonly property real minSpeed: 0.25
+  readonly property real maxSpeed: 2.0
+  property real playbackSpeed: 1.0
   // Per-monitor clips: { "HDMI-A-1": "/path/clip.mp4", "DP-2": "" }.
   // A present key wins over videoPath/output for that monitor; "" means the
   // monitor stays on the static wallpaper. Keys for disconnected monitors are
@@ -264,7 +279,8 @@ Item {
       enabled: root.enabled,
       output: root.output,
       pauseOnFullscreen: root.pauseOnFullscreen,
-      screenVideos: root.screenVideos || ({})
+      screenVideos: root.screenVideos || ({}),
+      playbackSpeed: root.playbackSpeed
     }, null, 2) + "\n"
     root.writeState(payload)
   }
@@ -317,6 +333,7 @@ Item {
           root.screenVideos = root.normalizeScreenVideos(o.screenVideos)
           root._stateHadScreens = true
         }
+        if (o.playbackSpeed !== undefined) root.playbackSpeed = root.safeSpeed(o.playbackSpeed)
         return true
       }
     } catch (e) {
@@ -583,6 +600,7 @@ Item {
         id: playerA
         videoOutput: outA
         loops: MediaPlayer.Infinite
+        playbackRate: root.playbackSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerA, err, str) }
       }
@@ -591,6 +609,7 @@ Item {
         id: playerB
         videoOutput: outB
         loops: MediaPlayer.Infinite
+        playbackRate: root.playbackSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerB, err, str) }
       }
@@ -722,7 +741,8 @@ Item {
         for (var i = 0; i < root.activeScreens.length; i++) a.push(String(root.activeScreens[i].name))
         return a
       })(),
-      fullscreenMonitors: Object.keys(root.fullscreenMonitors)
+      fullscreenMonitors: Object.keys(root.fullscreenMonitors),
+      playbackSpeed: root.playbackSpeed
     }
   }
 
@@ -855,6 +875,12 @@ Item {
     return root.statusObject()
   }
 
+  function applySetSpeed(v) {
+    root.playbackSpeed = root.safeSpeed(v)
+    root.persistState()
+    return root.statusObject()
+  }
+
   IpcHandler {
     target: "motion-wallpaper"
 
@@ -915,6 +941,10 @@ Item {
 
     function status(): string {
       return JSON.stringify(root.statusObject())
+    }
+
+    function setSpeed(value: string): string {
+      return JSON.stringify(root.applySetSpeed(value))
     }
 
     function ping(): string { return "ok" }

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "id": "nosignal.motion-wallpaper",
   "name": "Motion Wallpaper",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "author": "Gavin Nugent",
   "license": "MIT",
-  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
+  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, adjustable playback speed, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
   "kinds": ["service", "bar-widget"],
   "entryPoints": {
     "service": "Service.qml",

--- a/motion-wallpaper
+++ b/motion-wallpaper
@@ -213,6 +213,15 @@ cmd_autopause() {
   esac
 }
 
+cmd_speed() {
+  require_plugin
+  local v="${1:-}"
+  case "$v" in
+    ""|*[!0-9.]*|*.*.*) err "usage: motion-wallpaper speed <0.25-2>"; exit 1 ;;
+  esac
+  ipc setSpeed "$v" >/dev/null
+}
+
 case "${1:-status}" in
   status|"") cmd_status ;;
   screens)   cmd_screens ;;
@@ -225,6 +234,7 @@ case "${1:-status}" in
   resume)    require_plugin; ipc resume >/dev/null ;;
   screen)    shift; cmd_screen "${1:-}" ;;
   autopause) shift; cmd_autopause "${1:-}" ;;
+  speed)     shift; cmd_speed "${1:-}" ;;
   -h|--help)
     cat <<USAGE
 $APP_NAME — control the omarchy-shell video wallpaper plugin.
@@ -241,6 +251,7 @@ Usage: ${0##*/} [command]
   pause | resume        Pause/resume playback.
   screen <name|all>     Coarse targeting for monitors with no clip of their own.
   autopause <on|off>    Pause video under fullscreen windows.
+  speed <0.25-2>        Playback speed, e.g. 1, 0.5, 0.66.
 
 Different clips on different screens:
   ${0##*/} play ~/Videos/a.mp4 DP-1


### PR DESCRIPTION
Speed slider in the panel, 0.25x to 2x. First of the two from #4.

Free rather than stepped, so 0.66 and 0.99 are reachable. Ticks sit at the round speeds.

- bound to `playbackRate` on both players, so the A/B pair stay in step through a cross-fade
- `safeSpeed()` clamps and rounds to 2dp instead of snapping, so a hand-edited state.json still can't push the decoder out of range
- dragging previews live, only the release calls `applySetSpeed` - otherwise a drag writes state.json on every pixel
- readout drops trailing zeros and is width-fitted, so the slack goes to the slider

`playbackSpeed` is optional on read, so an older state.json loads unchanged. CLI gets `speed`. README and NOTES updated, manifest to 0.4.0 - shout if you'd rather own the version bump.

MIT is fine by me.

Written with Claude as a pair-programming assistant; the commit carries a Co-Authored-By trailer. I've reviewed and tested it.
