### PR TITLE
Make Play, Stop, Pause and speed per-screen too

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -86,6 +86,31 @@ BarWidget {
     if (service) service.applySetSpeed(v)
     else ipc("setSpeed", String(v))
   }
+  // scope is "" / "all" for the global defaults, or a connector name.
+  function setRotation(mode, order, minutes, scope) {
+    var sc = String(scope || "")
+    if (service) service.applySetRotation(mode, order, minutes, sc)
+    else if (sc === "" || sc === "all") ipc("setRotation", String(mode), String(order), String(minutes))
+    else ipc("setRotationOn", sc, String(mode), String(order), String(minutes))
+  }
+  function setPlaylist(paths, scope) {
+    var sc = String(scope || "")
+    if (service) service.applySetPlaylist(paths, sc)
+    else if (sc === "" || sc === "all") ipc("setPlaylist", (paths || []).join(":"))
+    else ipc("setPlaylistOn", sc, (paths || []).join(":"))
+  }
+  function clearRotation(scope) {
+    var sc = String(scope || "")
+    if (sc === "" || sc === "all") return
+    if (service) service.applyClearScreenRotation(sc)
+    else ipc("clearRotationOn", sc)
+  }
+  function nextVideo(scope) {
+    var sc = String(scope || "")
+    if (service) service.applyNextVideo(sc)
+    else if (sc === "" || sc === "all") ipc("next")
+    else ipc("nextOn", sc)
+  }
   function setPauseOnFullscreen(on) {
     if (service) service.applySetPauseOnFullscreen(on ? "true" : "false")
     else ipc("setPauseOnFullscreen", on ? "true" : "false")

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -82,6 +82,10 @@ BarWidget {
     if (service) service.applySetOutput(name)
     else ipc("setOutput", name)
   }
+  function setSpeed(v) {
+    if (service) service.applySetSpeed(v)
+    else ipc("setSpeed", String(v))
+  }
   function setPauseOnFullscreen(on) {
     if (service) service.applySetPauseOnFullscreen(on ? "true" : "false")
     else ipc("setPauseOnFullscreen", on ? "true" : "false")

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -68,6 +68,34 @@ BarWidget {
     if (service) service.applySetScreenVideo(screen, "")
     else ipc("playOn", screen, "")
   }
+  // ---- scoped playback: "" / "all" = global, else one connector ----------
+  function togglePlayPauseScoped(scope) {
+    var sc = String(scope || "")
+    if (sc === "" || sc === "all") { togglePlayPause(); return }
+    if (!service) { ipc("toggleOnScreen", sc); return }
+    if (service.offFor(sc)) service.applyPlayScreen(sc)
+    else if (service.pausedFor(sc)) service.applyResumeScreen(sc)
+    else service.applyPauseScreen(sc)
+  }
+  function stopScoped(scope) {
+    var sc = String(scope || "")
+    if (sc === "" || sc === "all") { stopPlayback(); return }
+    if (service) service.applyStopScreen(sc)
+    else ipc("stopOnScreen", sc)
+  }
+  function setSpeedScoped(v, scope) {
+    var sc = String(scope || "")
+    if (sc === "" || sc === "all") { setSpeed(v); return }
+    if (service) service.applySetSpeedOn(sc, v)
+    else ipc("setSpeedOn", sc, String(v))
+  }
+  function followGlobalPlayback(scope) {
+    var sc = String(scope || "")
+    if (sc === "" || sc === "all") return
+    if (service) service.applyClearScreenPlayback(sc)
+    else ipc("followGlobalPlayback", sc)
+  }
+
   function togglePlayPause() {
     if (!service) { ipc("toggle"); return }
     if (!service.enabled) { service.applyPlay(""); return }

--- a/NOTES.md
+++ b/NOTES.md
@@ -47,7 +47,8 @@ Two sources, with a deliberate split:
   `Service.qml`'s `pluginConfig` falls back to `{}` when there is no entry, so
   every setting has a working default and the plugin runs without one.
 - **`~/.local/state/motion-wallpaper/state.json`** is the runtime truth. IPC
-  mutations (play/stop/toggle, screen, auto-pause, speed, rotation) write it,
+  mutations (play/stop/toggle, screen, auto-pause, speed, rotation, per-screen
+  profiles) write it,
   so they survive a shell restart and a reboot. Editing the config entry
   re-seeds the state file. It also carries `playbackSpeed`, the rotation
   globals and `screenRotation`; all of them are optional, so a state file
@@ -164,6 +165,28 @@ already ran `[ -f ]` on every entry, so trusting it avoids blanking a surface
 for a frame each time rotation swaps in a library clip. But the scan can be up
 to five minutes stale, so `statedPaths` records what the stat actually
 examined: once it has looked at a path and not found it, the stat wins.
+
+### Per-screen playback
+
+`screenRotation` carries `speed`, `off` and `paused` alongside the rotation
+fields, and `screenPlans` resolves them the same way: an entry overrides, no
+entry inherits the global. So the model is one shared default plus an optional
+profile per screen, and a screen with no entry still gets exactly the old
+global-only behaviour.
+
+`pathForScreen()` consults `offFor(name)` rather than the global `enabled`, so a
+screen with its own `off` decides for itself while everything else still obeys
+the global Stop. Each surface reads its own `paused` and `speed` off its plan,
+so `playbackRate` is bound per monitor.
+
+Two details worth keeping:
+
+- `applyPlayScreen()` clears a global Stop first. Otherwise playing one screen
+  would set `off: false` on it and still render nothing, because
+  `pathForScreen()` would fall through to the global.
+- Writing `undefined` removes a field, and an entry left holding nothing is
+  deleted, so `hasOwnProfile()` never reports a profile that no longer says
+  anything.
 
 ### Cross-fade on clip change
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -47,8 +47,11 @@ Two sources, with a deliberate split:
   `Service.qml`'s `pluginConfig` falls back to `{}` when there is no entry, so
   every setting has a working default and the plugin runs without one.
 - **`~/.local/state/motion-wallpaper/state.json`** is the runtime truth. IPC
-  mutations (play/stop/toggle, screen, auto-pause, speed) write it, so they survive a
-  shell restart and a reboot. Editing the config entry re-seeds the state file.
+  mutations (play/stop/toggle, screen, auto-pause, speed, rotation) write it,
+  so they survive a shell restart and a reboot. Editing the config entry
+  re-seeds the state file. It also carries `playbackSpeed`, the rotation
+  globals and `screenRotation`; all of them are optional, so a state file
+  written by an older version still loads.
 
 That split is why there is no autostart step: `play` means it returns after a
 reboot, `stop` means it stays off.
@@ -111,6 +114,56 @@ range, but any value inside it is honoured.
 The panel drives `playbackSpeed` directly while the slider is dragged and only
 calls `applySetSpeed` on release. A drag would otherwise write `state.json` on
 every pixel.
+
+### Rotation
+
+Off unless asked for: with `rotationMode` `"off"` the clip resolution below is
+byte-for-byte what it was before rotation existed.
+
+Settings live in two layers:
+
+- the **globals** (`rotationMode`, `rotationOrder`, `rotationInterval`,
+  `playlist`) are what the panel edits under *All screens*;
+- **`screenRotation`** is `{ "DP-1": { mode, order, interval, playlist } }`.
+  A screen with no entry follows the globals.
+
+`rotModeFor` / `rotOrderFor` / `rotIntervalFor` / `rotPlaylistFor` resolve
+override-then-global, and `rotationPoolFor` / `rotationActiveFor` build on
+them. `normalizeScreenRotation()` runs every field through the same validators
+as the globals, on the same reasoning as `normalizeScreenVideos()`.
+
+Because those are functions, QML cannot tell when to re-evaluate a binding that
+calls them. `rotRevision` is an integer bumped on every rotation-shaped change;
+bindings read it as a dependency. It is a workaround, not a design — the
+alternative was mirroring every derived value into its own property per screen.
+
+`rotCurrent` / `rotCursor` are `{ connector: ... }` and deliberately **not**
+persisted: rotation re-seeds on start. Each screen keeps its own cursor, so two
+monitors sharing a playlist sit at different points in it.
+
+There is no global rotation timer, because one timer cannot express two
+intervals. Each monitor's surface in the `Variants` delegate owns a `Timer` at
+that screen's interval, gated on `shouldPlay` so a fullscreen window does not
+churn wallpapers behind it. A screen whose rotation is active always has a
+surface, so the delegate is a safe place for it.
+
+Rotation takes precedence over `screenVideos` while active — that clip is just
+what is showing there now. `screenVideos` is never rewritten by rotation, so
+turning it off restores the previous assignment. A monitor explicitly blanked
+(`""`) stays blank; that is the per-screen opt-out.
+
+#### The library, and why `pathExists` has two sources
+
+Rotation has to keep working with the panel shut, so the `~/Videos` scan moved
+out of `Panel.qml` into the service; the panel reads `availableVideos` through
+it. `rescanLibrary()` also runs on a 5-minute timer so new clips join without
+opening the panel.
+
+`pathExists()` consults the async stat first and the scan second. The scan
+already ran `[ -f ]` on every entry, so trusting it avoids blanking a surface
+for a frame each time rotation swaps in a library clip. But the scan can be up
+to five minutes stale, so `statedPaths` records what the stat actually
+examined: once it has looked at a path and not found it, the stat wins.
 
 ### Cross-fade on clip change
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -47,7 +47,7 @@ Two sources, with a deliberate split:
   `Service.qml`'s `pluginConfig` falls back to `{}` when there is no entry, so
   every setting has a working default and the plugin runs without one.
 - **`~/.local/state/motion-wallpaper/state.json`** is the runtime truth. IPC
-  mutations (play/stop/toggle, screen, auto-pause) write it, so they survive a
+  mutations (play/stop/toggle, screen, auto-pause, speed) write it, so they survive a
   shell restart and a reboot. Editing the config entry re-seeds the state file.
 
 That split is why there is no autostart step: `play` means it returns after a
@@ -99,6 +99,18 @@ means what it says (and self-heals a stale `output` left by the CLI).
 click would flatten a per-screen setup — so the panel opens aimed at its own
 monitor instead. The bar mounts one widget per screen, so "its own monitor" is
 `button.QsWindow.window.screen.name`, surfaced as `screenName` on the widget.
+
+### Playback speed
+
+`playbackSpeed` on the service is bound to `playbackRate` on both players of
+every surface, so the A/B cross-fade pair stay in step. `safeSpeed()` clamps
+into `minSpeed`..`maxSpeed` and rounds to two decimals rather than snapping to
+a fixed set — a hand-edited `state.json` still cannot drive the decoder out of
+range, but any value inside it is honoured.
+
+The panel drives `playbackSpeed` directly while the slider is dragged and only
+calls `applySetSpeed` on release. A drag would otherwise write `state.json` on
+every pixel.
 
 ### Cross-fade on clip change
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -79,8 +79,10 @@ Item {
     if (!service) return "Service unavailable"
     if (videoPath === "") return scope === "all" ? "No video selected" : "Screen off"
     if (!videoExists) return "File missing"
-    if (!service.enabled) return "Stopped"
-    if (service.manualPaused) return "Paused"
+    // Scoped, so a screen stopped or paused on its own reads correctly rather
+    // than reporting the global state it is overriding.
+    if (scopedOff) return "Stopped"
+    if (scopedPaused) return "Paused"
     return "Playing"
   }
   // Naming one clip would be a lie while the screens are showing different
@@ -90,9 +92,29 @@ Item {
     return stateText + (videoName !== "" ? "  ·  " + videoName : "")
   }
 
-  readonly property bool isPlaying: !!service && service.enabled && service.rendering === true
-                                    && !service.manualPaused
-  readonly property bool isPaused: !!service && service.enabled && service.manualPaused
+  // Playback reads follow the SCREEN selector, like the clip list and rotation.
+  readonly property bool scopedOff: {
+    if (!service) return true
+    if (panel.scope === "all") return !service.enabled
+    return service.offFor(panel.scope) === true
+  }
+  readonly property bool scopedPaused: {
+    if (!service) return false
+    if (panel.scope === "all") return service.manualPaused === true
+    return service.pausedFor(panel.scope) === true
+  }
+  // True when this screen sets its own Play/Stop/Pause or speed.
+  readonly property bool scopeHasOwnPlayback: {
+    if (!service || panel.scope === "all") return false
+    return service.hasOwnPlayback(panel.scope) === true
+  }
+
+  readonly property bool isPlaying: {
+    if (!service || panel.scopedOff || panel.scopedPaused) return false
+    return panel.scope === "all" ? service.rendering === true
+                                 : service.urlForScreen(panel.scope) !== ""
+  }
+  readonly property bool isPaused: !panel.scopedOff && panel.scopedPaused
 
   // ---- screen options ----------------------------------------------------
   // Each screen is labelled with the clip it is set to, so the dropdown
@@ -109,12 +131,18 @@ Item {
   }
 
   // Do the screens disagree about what they are playing?
+  // Screens count as differing when they show different clips OR when any of
+  // them has a profile of its own. Without the second half a screen that was
+  // stopped or slowed on its own would still open the panel on "All screens",
+  // hiding the difference and aiming the next click at every monitor.
   readonly property bool screensDiffer: {
     if (!service || !multiScreen) return false
     var s = Quickshell.screens
     var first = null
     for (var i = 0; i < s.length; i++) {
-      var p = String(service.configuredPathForScreen(String(s[i].name)) || "")
+      var n = String(s[i].name)
+      if (service.hasOwnProfile(n) || service.hasOwnPlayback(n)) return true
+      var p = String(service.configuredPathForScreen(n) || "")
       if (first === null) first = p
       else if (p !== first) return true
     }
@@ -155,7 +183,9 @@ Item {
   property real pendingSpeed: -1
 
   readonly property real serviceSpeed: {
-    var v = panel.service ? Number(panel.service.playbackSpeed) : 1
+    if (!panel.service) return 1
+    var v = panel.scope === "all" ? Number(panel.service.playbackSpeed)
+                                  : Number(panel.service.speedFor(panel.scope))
     return (isFinite(v) && v > 0) ? v : 1
   }
 
@@ -265,7 +295,7 @@ Item {
         iconText: panel.isPlaying ? "󰏤" : "󰐊"
         text: panel.isPlaying ? "Pause" : (panel.isPaused ? "Resume" : "Play")
         bordered: true
-        onClicked: if (panel.widget) panel.widget.togglePlayPause()
+        onClicked: if (panel.widget) panel.widget.togglePlayPauseScoped(panel.scope)
       }
 
       Button {
@@ -275,8 +305,8 @@ Item {
         iconText: "󰓛"
         text: "Stop"
         bordered: true
-        opacity: (panel.service && panel.service.enabled) ? 1.0 : 0.5
-        onClicked: if (panel.widget) panel.widget.stopPlayback()
+        opacity: panel.scopedOff ? 0.5 : 1.0
+        onClicked: if (panel.widget) panel.widget.stopScoped(panel.scope)
       }
     }
 
@@ -318,7 +348,8 @@ Item {
     PanelSeparator { foreground: panel.fg }
 
     PanelSectionHeader {
-      text: "SPEED"
+      text: !panel.multiScreen ? "SPEED"
+          : (panel.scope === "all" ? "SPEED · ALL SCREENS" : "SPEED · " + panel.scope)
       foreground: panel.fg
       fontFamily: panel.fontFamily
     }
@@ -344,13 +375,15 @@ Item {
         onMoved: function(v) {
           panel.pendingSpeed = panel.roundSpeed(v)
           // Live preview without writing state.json on every pixel; the
-          // release below is what persists.
-          if (panel.service) panel.service.playbackSpeed = panel.pendingSpeed
+          // release below is what persists. Only the global slider can preview
+          // this way - a scoped one has to go through the profile.
+          if (panel.service && panel.scope === "all")
+            panel.service.playbackSpeed = panel.pendingSpeed
         }
         onReleased: function(v) {
           var final = panel.roundSpeed(v)
           panel.pendingSpeed = -1
-          if (panel.widget) panel.widget.setSpeed(final)
+          if (panel.widget) panel.widget.setSpeedScoped(final, panel.scope)
         }
       }
 
@@ -394,8 +427,9 @@ Item {
       width: parent.width
       text: panel.scope === "all"
           ? "Shared default. Screens with their own settings ignore this."
-          : (panel.scopeHasOwnProfile ? panel.scope + " has its own settings."
-                                      : panel.scope + " follows the shared default — changing anything here gives it its own.")
+          : ((panel.scopeHasOwnProfile || panel.scopeHasOwnPlayback)
+              ? panel.scope + " has its own settings."
+              : panel.scope + " follows the shared default — changing anything gives it its own.")
       color: panel.dim
       font.family: panel.fontFamily
       font.pixelSize: Style.font.bodySmall
@@ -433,15 +467,37 @@ Item {
       }
     }
 
-    Dropdown {
-      id: rotIntervalDropdown
+    // The interval and "Next video" share a row: both only exist while rotation
+    // is on, and the dropdown does not need the full width for "15 minutes".
+    Row {
       width: parent.width
+      spacing: Style.spacing.controlGap
       visible: panel.rotationMode !== "off"
-      label: "CHANGE EVERY"
-      options: panel.intervalOptions
-      value: String(panel.rotationInterval)
-      onChanged: function(v) {
-        if (panel.widget) panel.widget.setRotation(panel.rotationMode, panel.rotationOrder, Number(v), panel.scope)
+
+      Dropdown {
+        id: rotIntervalDropdown
+        width: parent.width - nextVideoBtn.width - Style.spacing.controlGap
+        // Match the button, which sizes itself from its text padding and comes
+        // out taller than the 28px control default.
+        rowHeight: nextVideoBtn.height
+        label: "CHANGE EVERY"
+        options: panel.intervalOptions
+        value: String(panel.rotationInterval)
+        onChanged: function(v) {
+          if (panel.widget) panel.widget.setRotation(panel.rotationMode, panel.rotationOrder, Number(v), panel.scope)
+        }
+      }
+
+      // Sits on the dropdown's trigger, not level with its label above it.
+      Button {
+        id: nextVideoBtn
+        anchors.bottom: parent.bottom
+        foreground: panel.fg
+        fontFamily: panel.fontFamily
+        iconText: "󰒭"
+        text: "Next video"
+        bordered: true
+        onClicked: if (panel.widget) panel.widget.nextVideo(panel.scope)
       }
     }
 
@@ -459,30 +515,6 @@ Item {
       onChanged: function(vals) { if (panel.widget) panel.widget.setPlaylist(vals, panel.scope) }
     }
 
-    Row {
-      width: parent.width
-      spacing: Style.spacing.controlGap
-
-      Button {
-        visible: panel.rotationMode !== "off"
-        foreground: panel.fg
-        fontFamily: panel.fontFamily
-        iconText: "󰒭"
-        text: "Next video"
-        bordered: true
-        onClicked: if (panel.widget) panel.widget.nextVideo(panel.scope)
-      }
-
-      Button {
-        visible: panel.scopeHasOwnProfile
-        foreground: panel.fg
-        fontFamily: panel.fontFamily
-        iconText: "󰑐"
-        text: "Follow default"
-        bordered: true
-        onClicked: if (panel.widget) panel.widget.clearRotation(panel.scope)
-      }
-    }
 
     Text {
       textFormat: Text.PlainText

--- a/Panel.qml
+++ b/Panel.qml
@@ -132,6 +132,32 @@ Item {
 
   function rescan() { scanProc.running = true }
 
+  // ---- playback speed ----
+  readonly property real minSpeed: panel.service ? Number(panel.service.minSpeed) : 0.25
+  readonly property real maxSpeed: panel.service ? Number(panel.service.maxSpeed) : 2.0
+  // Reference marks at the round speeds.
+  readonly property var speedMarks: [0.25, 0.5, 0.75, 1.0, 1.5, 2.0]
+
+  // < 0 unless a drag is in flight, so the readout follows the knob.
+  property real pendingSpeed: -1
+
+  readonly property real serviceSpeed: {
+    var v = panel.service ? Number(panel.service.playbackSpeed) : 1
+    return (isFinite(v) && v > 0) ? v : 1
+  }
+
+  readonly property real speedValue: panel.pendingSpeed >= 0 ? panel.pendingSpeed
+                                                             : panel.serviceSpeed
+
+  function roundSpeed(v) { return Math.round(Number(v) * 100) / 100 }
+
+  // Trailing zeros dropped: 1x, 0.5x, 0.66x - never 1.00x.
+  readonly property string speedLabel: {
+    var n = panel.roundSpeed(panel.speedValue)
+    var t = n.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")
+    return t + "x"
+  }
+
   Component.onCompleted: { rescan(); resetScope() }
 
   Connections {
@@ -297,6 +323,69 @@ Item {
       foreground: panel.fg
       checked: panel.service ? panel.service.pauseOnFullscreen === true : true
       onClicked: if (panel.widget) panel.widget.setPauseOnFullscreen(!checked)
+    }
+
+    // ---------- playback speed ----------
+    PanelSeparator { foreground: panel.fg }
+
+    PanelSectionHeader {
+      text: "SPEED"
+      foreground: panel.fg
+      fontFamily: panel.fontFamily
+    }
+
+    // Free over the whole range at 2-decimal precision; the ticks are just
+    // visual anchors at the round speeds.
+    Row {
+      width: parent.width
+      spacing: Style.spacing.controlGap
+
+      PanelSlider {
+        id: speedSlider
+        bar: panel.bar
+        width: parent.width - speedReadout.width - Style.spacing.controlGap
+        anchors.verticalCenter: parent.verticalCenter
+        minimum: panel.minSpeed
+        maximum: panel.maxSpeed
+        // PanelSlider ignores `step` and only quantises when `integer` is
+        // set, so the 2-decimal rounding is applied here.
+        integer: false
+        tickCount: panel.speedMarks.length
+        value: panel.speedValue
+        onMoved: function(v) {
+          panel.pendingSpeed = panel.roundSpeed(v)
+          // Live preview without writing state.json on every pixel; the
+          // release below is what persists.
+          if (panel.service) panel.service.playbackSpeed = panel.pendingSpeed
+        }
+        onReleased: function(v) {
+          var final = panel.roundSpeed(v)
+          panel.pendingSpeed = -1
+          if (panel.widget) panel.widget.setSpeed(final)
+        }
+      }
+
+      Text {
+        id: speedReadout
+        textFormat: Text.PlainText
+        anchors.verticalCenter: parent.verticalCenter
+        // Sized to the widest label so the slack goes back to the slider.
+        width: speedMetrics.width
+        horizontalAlignment: Text.AlignRight
+        text: panel.speedLabel
+        color: panel.fg
+        font.family: panel.fontFamily
+        font.pixelSize: Style.font.subtitle
+        font.bold: true
+      }
+
+      TextMetrics {
+        id: speedMetrics
+        font.family: panel.fontFamily
+        font.pixelSize: Style.font.subtitle
+        font.bold: true
+        text: "0.25x"
+      }
     }
 
     // ---------- video library ----------

--- a/Panel.qml
+++ b/Panel.qml
@@ -124,17 +124,30 @@ Item {
   // ---- video discovery ---------------------------------------------------
   // Hard cap on how many clips the panel will hold and draw. The CLI takes an
   // arbitrary path, so nothing becomes unreachable by capping the browser.
-  readonly property int scanLimit: 500
-  readonly property int entryLimit: 20000   // directory entries examined per folder
-  readonly property int scanSeconds: 5      // hard deadline on the scan process
-  property bool videosTruncated: false
-  property var videos: []   // [{ path, name }]
+  // Read-through to the service's scan rather than a second one.
+  readonly property int scanLimit: panel.service ? panel.service.scanLimit : 500
+  readonly property bool videosTruncated: panel.service ? panel.service.videosTruncated === true : false
+  readonly property var videos: panel.service ? (panel.service.availableVideos || []) : []
 
-  function rescan() { scanProc.running = true }
+  function rescan() { if (panel.service) panel.service.rescanLibrary() }
 
-  // ---- playback speed ----
+  Component.onCompleted: { rescan(); resetScope() }
+
+  Connections {
+    target: panel.widget || null
+    function onOpenedChanged() {
+      if (!panel.widget || !panel.widget.opened) return
+      panel.rescan()
+      panel.resetScope()
+    }
+  }
+
+  // ---- speed + rotation reads -------------------------------------------
+  // All of these read THROUGH the service, so the panel shows live truth even
+  // when the CLI changed something while the dropdown was open.
   readonly property real minSpeed: panel.service ? Number(panel.service.minSpeed) : 0.25
   readonly property real maxSpeed: panel.service ? Number(panel.service.maxSpeed) : 2.0
+
   // Reference marks at the round speeds.
   readonly property var speedMarks: [0.25, 0.5, 0.75, 1.0, 1.5, 2.0]
 
@@ -151,89 +164,65 @@ Item {
 
   function roundSpeed(v) { return Math.round(Number(v) * 100) / 100 }
 
-  // Trailing zeros dropped: 1x, 0.5x, 0.66x - never 1.00x.
+  // Trailing zeros dropped: 1x, 0.5x, 0.66x — never 1.00x.
   readonly property string speedLabel: {
     var n = panel.roundSpeed(panel.speedValue)
     var t = n.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")
     return t + "x"
   }
 
-  Component.onCompleted: { rescan(); resetScope() }
-
-  Connections {
-    target: panel.widget || null
-    function onOpenedChanged() {
-      if (!panel.widget || !panel.widget.opened) return
-      panel.rescan()
-      panel.resetScope()
-    }
+  // Rotation reads follow the SCREEN selector: "all" is the global default,
+  // a screen is its effective settings (own profile, else inherited). Reading
+  // the service's screenPlans is what makes these live.
+  readonly property var scopePlan: {
+    if (!panel.service || panel.scope === "all") return null
+    var plans = panel.service.screenPlans || ({})
+    return plans[panel.scope] || null
   }
 
-  // The shell process is long-lived, so nothing here may grow with the user's
-  // video folder — not the buffer, not the list, not the traversal, and not
-  // how long the scan is allowed to take.
-  //
-  // Capping matches alone is not enough, which is the trap the first attempt
-  // fell into. `head` can only kill the producer once the producer has
-  // *emitted* enough lines, so a folder of a million non-videos yields nothing
-  // to cap and gets walked in full. Three separate bounds are needed:
-  //
-  //   * `ls -U` streams entries in directory order and is cut off by
-  //     `head -n entryLimit`, so the number of entries EXAMINED is bounded,
-  //     not just the number matched;
-  //   * the extension filter runs before any `stat`, so at most `scanLimit`
-  //     files per directory are ever tested with `[ -f ]`;
-  //   * `timeout` puts a hard ceiling on the process's lifetime whatever the
-  //     filesystem does — a slow or hung mount cannot pin the scan open.
-  //
-  // Arguments go in as positional parameters rather than interpolated into the
-  // script text, so no path can alter the command.
-  readonly property string scanScript:
-    'lim=$1; emax=$2\n' +
-    'for d in "$HOME/Videos/Wallpapers" "$HOME/Videos"; do\n' +
-    '  [ -d "$d" ] || continue\n' +
-    '  entries=$(ls -U -1 -- "$d" 2>/dev/null | head -n "$emax")\n' +
-    '  [ -n "$entries" ] || continue\n' +
-    '  if [ "$(printf "%s\\n" "$entries" | wc -l)" -ge "$emax" ]; then\n' +
-    '    printf "TRUNC\\n" >&2\n' +
-    '  fi\n' +
-    '  printf "%s\\n" "$entries" |\n' +
-    '    grep -iE "\\.(mp4|mkv|webm|mov|avi)$" | head -n "$lim" |\n' +
-    '    while IFS= read -r f; do\n' +
-    '      [ -f "$d/$f" ] && printf "%s/%s\\n" "$d" "$f"\n' +
-    '    done\n' +
-    'done | sort -u | head -n "$lim"\n'
+  readonly property string rotationMode:
+    panel.scope === "all" ? (panel.service ? String(panel.service.rotationMode || "off") : "off")
+                          : (panel.scopePlan ? String(panel.scopePlan.mode) : "off")
 
-  Process {
-    id: scanProc
-    command: ["timeout", "-k", "1", String(panel.scanSeconds),
-              "bash", "-c", panel.scanScript, "_",
-              String(panel.scanLimit + 1), String(panel.entryLimit)]
-    // Hitting the entry cap exits 0, so it would otherwise truncate in
-    // silence — which reads as "there was nothing else", a worse lie than a
-    // cap. The script says so on stderr; a non-zero exit (the deadline firing,
-    // or the pipeline cut short) is the other way the view can be partial.
-    onExited: function(code) { if (code !== 0) panel.videosTruncated = true }
-    stderr: StdioCollector {
-      onStreamFinished: if (String(text || "").indexOf("TRUNC") !== -1) panel.videosTruncated = true
-    }
-    stdout: StdioCollector {
-      onStreamFinished: {
-        var seen = ({})
-        var list = []
-        panel.videosTruncated = false
-        var lines = String(text || "").split("\n")
-        for (var i = 0; i < lines.length; i++) {
-          var p = lines[i].trim()
-          if (!p || seen[p]) continue
-          seen[p] = true
-          if (list.length >= panel.scanLimit) { panel.videosTruncated = true; break }
-          list.push({ path: p, name: p.split("/").pop() })
-        }
-        panel.videos = list
-      }
-    }
+  readonly property string rotationOrder:
+    panel.scope === "all" ? (panel.service ? String(panel.service.rotationOrder || "shuffle") : "shuffle")
+                          : (panel.scopePlan ? String(panel.scopePlan.order) : "shuffle")
+
+  readonly property int rotationInterval:
+    panel.scope === "all" ? (panel.service ? Number(panel.service.rotationInterval || 10) : 10)
+                          : (panel.scopePlan ? Number(panel.scopePlan.interval) : 10)
+
+  // True when this screen has been given settings of its own.
+  readonly property bool scopeHasOwnProfile: panel.scopePlan ? panel.scopePlan.own === true : false
+
+  readonly property var intervalOptions: [
+    { value: "1",  label: "1 minute"   },
+    { value: "2",  label: "2 minutes"  },
+    { value: "5",  label: "5 minutes"  },
+    { value: "10", label: "10 minutes" },
+    { value: "15", label: "15 minutes" },
+    { value: "30", label: "30 minutes" },
+    { value: "60", label: "1 hour"     }
+  ]
+
+  // Full path as the value, bare filename as the label.
+  readonly property var playlistOptions: {
+    var out = []
+    var v = panel.videos || []
+    for (var i = 0; i < v.length; i++)
+      out.push({ value: String(v[i].path), label: String(v[i].name) })
+    return out
   }
+
+  readonly property var playlistValues: {
+    var out = []
+    if (!panel.service) return out
+    var pl = panel.scope === "all" ? (panel.service.playlist || [])
+                                   : (panel.scopePlan ? panel.scopePlan.playlist : [])
+    for (var i = 0; i < pl.length; i++) out.push(String(pl[i]))
+    return out
+  }
+
 
   implicitWidth: Style.space(320)
   implicitHeight: col.implicitHeight
@@ -386,6 +375,124 @@ Item {
         font.bold: true
         text: "0.25x"
       }
+    }
+
+    // ---------- rotation ----------
+    PanelSeparator { foreground: panel.fg }
+
+    PanelSectionHeader {
+      text: !panel.multiScreen ? "ROTATION"
+          : (panel.scope === "all" ? "ROTATION · ALL SCREENS" : "ROTATION · " + panel.scope)
+      foreground: panel.fg
+      fontFamily: panel.fontFamily
+    }
+
+    // The same controls mean two different things depending on scope.
+    Text {
+      textFormat: Text.PlainText
+      visible: panel.multiScreen
+      width: parent.width
+      text: panel.scope === "all"
+          ? "Shared default. Screens with their own settings ignore this."
+          : (panel.scopeHasOwnProfile ? panel.scope + " has its own settings."
+                                      : panel.scope + " follows the shared default — changing anything here gives it its own.")
+      color: panel.dim
+      font.family: panel.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
+    }
+
+    Dropdown {
+      id: rotModeDropdown
+      width: parent.width
+      label: "MODE"
+      options: [
+        { value: "off",      label: "Off — one video" },
+        { value: "all",      label: "Rotate all videos" },
+        { value: "selected", label: "Rotate chosen videos" }
+      ]
+      value: panel.rotationMode
+      onChanged: function(v) {
+        if (panel.widget) panel.widget.setRotation(String(v), panel.rotationOrder, panel.rotationInterval, panel.scope)
+      }
+    }
+
+    // Hidden until rotation is on rather than offering settings that do nothing.
+    ButtonGroup {
+      width: parent.width
+      visible: panel.rotationMode !== "off"
+      foreground: panel.fg
+      fontFamily: panel.fontFamily
+      options: [
+        { value: "shuffle",    label: "Shuffle" },
+        { value: "sequential", label: "In order" }
+      ]
+      value: panel.rotationOrder
+      onChanged: function(v) {
+        if (panel.widget) panel.widget.setRotation(panel.rotationMode, String(v), panel.rotationInterval, panel.scope)
+      }
+    }
+
+    Dropdown {
+      id: rotIntervalDropdown
+      width: parent.width
+      visible: panel.rotationMode !== "off"
+      label: "CHANGE EVERY"
+      options: panel.intervalOptions
+      value: String(panel.rotationInterval)
+      onChanged: function(v) {
+        if (panel.widget) panel.widget.setRotation(panel.rotationMode, panel.rotationOrder, Number(v), panel.scope)
+      }
+    }
+
+    MultiSelect {
+      id: playlistSelect
+      width: parent.width
+      visible: panel.rotationMode === "selected"
+      label: "VIDEOS IN ROTATION"
+      noSelectionText: "None chosen — nothing will rotate"
+      emptyText: "Drop clips in ~/Videos"
+      foreground: panel.fg
+      fontFamily: panel.fontFamily
+      options: panel.playlistOptions
+      values: panel.playlistValues
+      onChanged: function(vals) { if (panel.widget) panel.widget.setPlaylist(vals, panel.scope) }
+    }
+
+    Row {
+      width: parent.width
+      spacing: Style.spacing.controlGap
+
+      Button {
+        visible: panel.rotationMode !== "off"
+        foreground: panel.fg
+        fontFamily: panel.fontFamily
+        iconText: "󰒭"
+        text: "Next video"
+        bordered: true
+        onClicked: if (panel.widget) panel.widget.nextVideo(panel.scope)
+      }
+
+      Button {
+        visible: panel.scopeHasOwnProfile
+        foreground: panel.fg
+        fontFamily: panel.fontFamily
+        iconText: "󰑐"
+        text: "Follow default"
+        bordered: true
+        onClicked: if (panel.widget) panel.widget.clearRotation(panel.scope)
+      }
+    }
+
+    Text {
+      textFormat: Text.PlainText
+      visible: panel.rotationMode === "selected" && panel.playlistValues.length === 0
+      width: parent.width
+      text: "Pick at least one video above, or rotation stays on the current clip."
+      color: panel.dim
+      font.family: panel.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
     }
 
     // ---------- video library ----------

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ motion-wallpaper pause           # pause / resume
 motion-wallpaper resume
 motion-wallpaper autopause off   # or: on
 motion-wallpaper speed 0.5       # playback speed, 0.25-2 (e.g. 1, 0.66)
+motion-wallpaper stop DP-2       # blank one monitor; the other keeps playing
+motion-wallpaper play DP-2       # and start it again
+motion-wallpaper speed 0.5 DP-1  # speed for just that monitor
+motion-wallpaper follow DP-1     # drop its own settings, follow the default
 ```
 
 ### With a keybind
@@ -157,6 +161,29 @@ A **SPEED** slider in the panel sets how fast the clip plays, anywhere from `0.2
 ```bash
 motion-wallpaper speed 0.5
 ```
+
+### One profile per screen
+
+Everything below the **SCREEN** dropdown follows it: the clip list, rotation, the speed slider, and Play/Stop/Pause. On *All screens* you are editing the shared default; on a named screen you are editing that screen alone.
+
+A screen with no settings of its own follows the shared default, so nothing changes until you give it some. Using any control while a screen is selected gives it its own; a line in the ROTATION section always says which of the two you are editing. To hand a screen back to the shared default, use the CLI:
+
+```bash
+motion-wallpaper follow DP-1              # rotation and playback
+motion-wallpaper follow DP-1 rotation     # or just one half
+```
+
+So one monitor can be stopped, slowed down, or rotating on its own schedule while the other carries on:
+
+```bash
+motion-wallpaper stop DP-2          # DP-1 keeps playing
+motion-wallpaper speed 0.5 DP-1     # only that monitor slows down
+motion-wallpaper pause DP-2         # freeze one screen
+motion-wallpaper play DP-2          # start it again
+motion-wallpaper follow DP-1        # back to the shared default
+```
+
+The global **Stop** still governs every screen that has no profile of its own, so the plugin behaves exactly as before for anyone not using this.
 
 ### Rotation
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ motion-wallpaper toggle          # flip on/off
 motion-wallpaper pause           # pause / resume
 motion-wallpaper resume
 motion-wallpaper autopause off   # or: on
+motion-wallpaper speed 0.5       # playback speed, 0.25-2 (e.g. 1, 0.66)
 ```
 
 ### With a keybind
@@ -148,6 +149,14 @@ motion-wallpaper screens          # check what landed where
 ```
 
 Connector names come from `hyprctl monitors`. A monitor keeps its clip while it is unplugged, so it comes back to the right one; a monitor you have never set follows the default `videoPath` (and the legacy `motion-wallpaper screen <name|all>` targeting, which only applies to monitors with no clip of their own).
+
+### Playback speed
+
+A **SPEED** slider in the panel sets how fast the clip plays, anywhere from `0.25x` to `2x`. It is free rather than stepped — `0.66` and `0.99` are as reachable as `1` — with tick marks at the round speeds as anchors. Dragging previews live; letting go saves. The speed applies to every monitor.
+
+```bash
+motion-wallpaper speed 0.5
+```
 
 ### Persistence
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,41 @@ A **SPEED** slider in the panel sets how fast the clip plays, anywhere from `0.2
 motion-wallpaper speed 0.5
 ```
 
+### Rotation
+
+**Off by default.** Left alone, the plugin behaves exactly as it always has: one clip per monitor until you change it. Turn rotation on and it cycles your library instead.
+
+In the panel's **ROTATION** section:
+
+| Setting | Options |
+|---|---|
+| Mode | Off · Rotate all videos · Rotate chosen videos |
+| Order | Shuffle · In order |
+| Change every | 1, 2, 5, 10, 15, 30 minutes, or 1 hour |
+| Videos in rotation | which clips to cycle, in *chosen* mode |
+
+**Each monitor can rotate differently.** The rotation controls follow the **SCREEN** dropdown, the same as the video list: on *All screens* you are editing the shared default, and on a named screen you are editing that screen alone. A screen with no settings of its own follows the shared default; changing anything while it is selected gives it its own, and a **Follow default** button hands it back.
+
+So one monitor can shuffle every five minutes while the other sits on a single clip:
+
+```bash
+motion-wallpaper rotate all shuffle 5 DP-1   # DP-1 shuffles the whole library
+motion-wallpaper rotate off "" "" DP-2       # DP-2 stays on its clip
+motion-wallpaper next DP-1                   # skip ahead now
+motion-wallpaper follow DP-1                 # back to the shared default
+```
+
+For *chosen* mode, pick the clips first:
+
+```bash
+motion-wallpaper playlist DP-1 ~/Videos/a.mp4 ~/Videos/b.mp4
+motion-wallpaper rotate selected order 10 DP-1
+```
+
+Each monitor keeps its own position in the list, so two screens sharing a playlist rarely show the same clip at the same time. Rotation drives monitors that have a clip of their own too — that clip is just what is showing there now — and turning rotation off restores it untouched. A monitor blanked with `off` stays blank: that is how you keep one screen out of the rotation entirely.
+
+Rotation pauses with the video, so a fullscreen window does not churn wallpapers behind it.
+
 ### Persistence
 
 A playing wallpaper **resumes automatically after a reboot** — the plugin persists its state to `~/.local/state/motion-wallpaper/state.json` and the shell loads it on login. There's no separate autostart step: `stop` means it stays off next boot, `play` means it comes back.

--- a/Service.qml
+++ b/Service.qml
@@ -99,6 +99,15 @@ Item {
   }
 
   // Clamp a value to a sane path string, or "" if it cannot be one.
+  // Clamp into range and round to 2 decimals. Rounding keeps the persisted
+  // value tidy and stops a drag from writing 0.6600000000000001.
+  function safeSpeed(v) {
+    var n = Number(v)
+    if (!isFinite(n) || n <= 0) return 1.0
+    n = Math.max(root.minSpeed, Math.min(root.maxSpeed, n))
+    return Math.round(n * 100) / 100
+  }
+
   function safePath(v) {
     if (v === null || v === undefined) return ""
     var t = String(v)
@@ -120,6 +129,12 @@ Item {
   property string output: "all"
   property bool pauseOnFullscreen: true
   property bool manualPaused: false   // set by IPC pause(); cleared by resume()/play()
+  // Playback speed multiplier applied to every surface. Free anywhere in the
+  // range at 2-decimal precision - clamped rather than snapped, so a
+  // hand-edited state.json cannot drive the decoder somewhere absurd.
+  readonly property real minSpeed: 0.25
+  readonly property real maxSpeed: 2.0
+  property real playbackSpeed: 1.0
   // Per-monitor clips: { "HDMI-A-1": "/path/clip.mp4", "DP-2": "" }.
   // A present key wins over videoPath/output for that monitor; "" means the
   // monitor stays on the static wallpaper. Keys for disconnected monitors are
@@ -264,7 +279,8 @@ Item {
       enabled: root.enabled,
       output: root.output,
       pauseOnFullscreen: root.pauseOnFullscreen,
-      screenVideos: root.screenVideos || ({})
+      screenVideos: root.screenVideos || ({}),
+      playbackSpeed: root.playbackSpeed
     }, null, 2) + "\n"
     root.writeState(payload)
   }
@@ -317,6 +333,7 @@ Item {
           root.screenVideos = root.normalizeScreenVideos(o.screenVideos)
           root._stateHadScreens = true
         }
+        if (o.playbackSpeed !== undefined) root.playbackSpeed = root.safeSpeed(o.playbackSpeed)
         return true
       }
     } catch (e) {
@@ -583,6 +600,7 @@ Item {
         id: playerA
         videoOutput: outA
         loops: MediaPlayer.Infinite
+        playbackRate: root.playbackSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerA, err, str) }
       }
@@ -591,6 +609,7 @@ Item {
         id: playerB
         videoOutput: outB
         loops: MediaPlayer.Infinite
+        playbackRate: root.playbackSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerB, err, str) }
       }
@@ -722,7 +741,8 @@ Item {
         for (var i = 0; i < root.activeScreens.length; i++) a.push(String(root.activeScreens[i].name))
         return a
       })(),
-      fullscreenMonitors: Object.keys(root.fullscreenMonitors)
+      fullscreenMonitors: Object.keys(root.fullscreenMonitors),
+      playbackSpeed: root.playbackSpeed
     }
   }
 
@@ -855,6 +875,12 @@ Item {
     return root.statusObject()
   }
 
+  function applySetSpeed(v) {
+    root.playbackSpeed = root.safeSpeed(v)
+    root.persistState()
+    return root.statusObject()
+  }
+
   IpcHandler {
     target: "motion-wallpaper"
 
@@ -915,6 +941,10 @@ Item {
 
     function status(): string {
       return JSON.stringify(root.statusObject())
+    }
+
+    function setSpeed(value: string): string {
+      return JSON.stringify(root.applySetSpeed(value))
     }
 
     function ping(): string { return "ok" }

--- a/Service.qml
+++ b/Service.qml
@@ -99,15 +99,6 @@ Item {
   }
 
   // Clamp a value to a sane path string, or "" if it cannot be one.
-  // Clamp into range and round to 2 decimals. Rounding keeps the persisted
-  // value tidy and stops a drag from writing 0.6600000000000001.
-  function safeSpeed(v) {
-    var n = Number(v)
-    if (!isFinite(n) || n <= 0) return 1.0
-    n = Math.max(root.minSpeed, Math.min(root.maxSpeed, n))
-    return Math.round(n * 100) / 100
-  }
-
   function safePath(v) {
     if (v === null || v === undefined) return ""
     var t = String(v)
@@ -129,17 +120,44 @@ Item {
   property string output: "all"
   property bool pauseOnFullscreen: true
   property bool manualPaused: false   // set by IPC pause(); cleared by resume()/play()
-  // Playback speed multiplier applied to every surface. Free anywhere in the
-  // range at 2-decimal precision - clamped rather than snapped, so a
-  // hand-edited state.json cannot drive the decoder somewhere absurd.
-  readonly property real minSpeed: 0.25
-  readonly property real maxSpeed: 2.0
-  property real playbackSpeed: 1.0
   // Per-monitor clips: { "HDMI-A-1": "/path/clip.mp4", "DP-2": "" }.
   // A present key wins over videoPath/output for that monitor; "" means the
   // monitor stays on the static wallpaper. Keys for disconnected monitors are
   // kept, so a screen gets its clip back when it is plugged in again.
   property var screenVideos: ({})
+
+  // ------------------------------------------------- speed + rotation state
+  // Playback speed multiplier applied to every surface. Free anywhere in the
+  // range at 2-decimal precision (0.66, 0.99, 1.37 ...) — clamped rather than
+  // snapped, so a hand-edited state.json still cannot drive the decoder
+  // somewhere absurd.
+  readonly property real minSpeed: 0.25
+  readonly property real maxSpeed: 2.0
+  property real playbackSpeed: 1.0
+
+  // Rotation is OFF by default: with rotationMode "off" this plugin behaves
+  // exactly as it did before — one clip, chosen by hand, until it is changed.
+  //   "off"      one clip (videoPath / screenVideos), never changes on its own
+  //   "all"      cycle every clip found in the library
+  //   "selected" cycle only the clips in `playlist`
+  property string rotationMode: "off"
+  property string rotationOrder: "shuffle"   // "shuffle" | "sequential"
+  property int rotationInterval: 10          // minutes between changes
+  property var playlist: []                  // paths, used when mode is "selected"
+
+  readonly property int maxPlaylist: 500     // matches the library scan cap
+  readonly property int minInterval: 1
+  readonly property int maxInterval: 60
+
+  // Per-monitor rotation position: each screen keeps its own cursor and clip.
+  // Ephemeral - not persisted, re-seeded on start.
+  // Per-screen overrides: { "DP-1": { mode, order, interval, playlist } }.
+  // A screen with no entry follows the globals above.
+  property var screenRotation: ({})
+
+  property var rotCurrent: ({})   // connector -> path showing right now
+  property var rotCursor: ({})    // connector -> index into rotationPool
+
   property bool _stateLoaded: false
   property bool _stateHadOutput: false  // state.json carried an explicit output
   property bool _stateHadPause: false   // state.json carried an explicit pauseOnFullscreen
@@ -169,10 +187,27 @@ Item {
   // (never a black or frozen frame). With per-monitor clips there can be
   // several paths in play, so one process checks them all in a batch.
   property var existingPaths: ({})
+  property var statedPaths: ({})   // paths the stat has actually examined
+
+  // The scan already ran `[ -f ]` on each entry, so these are known-good
+  // without waiting on the async stat below - which would otherwise blank the
+  // surface for a frame every time rotation swapped in a library clip.
+  readonly property var libraryPaths: {
+    var set = ({})
+    var av = root.availableVideos || []
+    for (var i = 0; i < av.length; i++) set[resolvePath(av[i].path)] = true
+    return set
+  }
 
   function pathExists(p) {
     var r = resolvePath(p)
-    return r !== "" && root.existingPaths[r] === true
+    if (r === "") return false
+    if (root.existingPaths[r] === true) return true
+    // The scan is a fallback for paths the stat has not covered yet. Once the
+    // stat has actually looked at a path and not found it, the stat wins —
+    // otherwise a clip deleted after the last scan keeps reporting as present
+    // for up to the rescan interval.
+    return root.libraryPaths[r] === true && root.statedPaths[r] !== true
   }
 
   // Every path the current state could render, resolved and deduplicated.
@@ -188,6 +223,21 @@ Item {
     add(root.videoPath)
     var sv = root.screenVideos || ({})
     for (var k in sv) add(sv[k])
+    // The rotation playlist has to be stat'd as well: rotationPool filters on
+    // pathExists(), so leaving these out makes every chosen clip look missing
+    // and the pool comes back empty.
+    var pl = root.playlist || []
+    for (var i = 0; i < pl.length; i++) add(pl[i])
+    // ...and every per-screen playlist, for the same reason.
+    var sr = root.screenRotation || ({})
+    for (var sk in sr) {
+      var spl = (sr[sk] && sr[sk].playlist) || []
+      for (var si = 0; si < spl.length; si++) add(spl[si])
+    }
+    // Whatever rotation is showing right now, so a clip deleted mid-cycle is
+    // noticed rather than trusted forever from the last scan.
+    var rc = root.rotCurrent || ({})
+    for (var rk in rc) add(rc[rk])
     return out
   }
 
@@ -195,6 +245,9 @@ Item {
     var paths = candidatePaths()
     if (paths.length === 0) { root.existingPaths = ({}); return }
     if (statProc.running) { statDebounce.restart(); return }
+    var asked = ({})
+    for (var i = 0; i < paths.length; i++) asked[paths[i]] = true
+    statProc.asked = asked
     statProc.command = root.timeoutPrefix.concat(
       ["bash", "-c", 'for p in "$@"; do [ -f "$p" ] && printf "%s\\n" "$p"; done', "_"]).concat(paths)
     statProc.running = true
@@ -202,9 +255,16 @@ Item {
 
   onVideoPathChanged: checkVideoFiles()
   onScreenVideosChanged: checkVideoFiles()
+  onPlaylistChanged: checkVideoFiles()
+  onRotCurrentChanged: checkVideoFiles()
 
   Process {
     id: statProc
+    // What this run was asked about. Published only once the run finishes, so
+    // statedPaths means what its name says; setting it at request time made
+    // pathExists() reject a path the stat had not looked at yet, dropping the
+    // surface for the round trip.
+    property var asked: ({})
     stdout: StdioCollector {
       onStreamFinished: {
         var set = ({})
@@ -214,6 +274,7 @@ Item {
           if (p) set[p] = true
         }
         root.existingPaths = set
+        root.statedPaths = statProc.asked
       }
     }
   }
@@ -228,6 +289,292 @@ Item {
   // Kept for the panel, the bar icon and the CLI: does the DEFAULT clip exist.
   readonly property bool videoFileExists: pathExists(videoPath)
 
+  // ------------------------------------------------ speed + rotation helpers
+  // Clamp into range and round to 2 decimals. Rounding keeps the persisted
+  // value tidy and stops a drag from writing 0.6600000000000001.
+  function safeSpeed(v) {
+    var n = Number(v)
+    if (!isFinite(n) || n <= 0) return 1.0
+    n = Math.max(root.minSpeed, Math.min(root.maxSpeed, n))
+    return Math.round(n * 100) / 100
+  }
+
+  function safeMode(v) {
+    var m = String(v || "")
+    return (m === "all" || m === "selected") ? m : "off"
+  }
+
+  function safeOrder(v) {
+    return String(v || "") === "sequential" ? "sequential" : "shuffle"
+  }
+
+  function safeInterval(v) {
+    var n = Math.round(Number(v))
+    if (!isFinite(n)) return 10
+    return Math.max(root.minInterval, Math.min(root.maxInterval, n))
+  }
+
+  // Same defensive shape as normalizeScreenVideos: a flat array of real paths,
+  // capped, deduplicated, anything else dropped rather than trusted.
+  function normalizePlaylist(v) {
+    var out = []
+    if (!v || typeof v !== "object" || typeof v.length !== "number") return out
+    var seen = ({})
+    for (var i = 0; i < v.length && out.length < root.maxPlaylist; i++) {
+      var p = root.safePath(v[i])
+      if (p === "" || Object.prototype.hasOwnProperty.call(seen, p)) continue
+      seen[p] = true
+      out.push(p)
+    }
+    return out
+  }
+
+  // Accept only { connector: { mode, order, interval, playlist } }; every field
+  // is run through the same validators as the globals, and anything unexpected
+  // is dropped rather than allowed to reach the render rule.
+  function normalizeScreenRotation(v) {
+    var out = ({})
+    if (!v || typeof v !== "object") return out
+    var n = 0
+    for (var k in v) {
+      if (n >= root.maxScreenVideos) break
+      var name = root.safeName(k, "")
+      if (name === "") continue
+      var o = v[k]
+      if (!o || typeof o !== "object") continue
+      var e = ({})
+      if (o.mode !== undefined) e.mode = root.safeMode(o.mode)
+      if (o.order !== undefined) e.order = root.safeOrder(o.order)
+      if (o.interval !== undefined) e.interval = root.safeInterval(o.interval)
+      if (o.playlist !== undefined) e.playlist = root.normalizePlaylist(o.playlist)
+      out[name] = e
+      n++
+    }
+    return out
+  }
+
+  // ------------------------------------------------------------ the library
+  // Lives here rather than in Panel.qml because rotation needs it with the
+  // panel shut; the panel reads `availableVideos` instead of scanning again.
+  readonly property int scanLimit: 500
+  readonly property int entryLimit: 20000
+  readonly property int scanSeconds: 5
+  property var availableVideos: []      // [{ path, name }]
+  property bool videosTruncated: false
+
+  readonly property string scanScript:
+    'lim=$1; emax=$2\n' +
+    'for d in "$HOME/Videos/Wallpapers" "$HOME/Videos"; do\n' +
+    '  [ -d "$d" ] || continue\n' +
+    '  entries=$(ls -U -1 -- "$d" 2>/dev/null | head -n "$emax")\n' +
+    '  [ -n "$entries" ] || continue\n' +
+    '  if [ "$(printf "%s\\n" "$entries" | wc -l)" -ge "$emax" ]; then\n' +
+    '    printf "TRUNC\\n" >&2\n' +
+    '  fi\n' +
+    '  printf "%s\\n" "$entries" |\n' +
+    '    grep -iE "\\.(mp4|mkv|webm|mov|avi)$" | head -n "$lim" |\n' +
+    '    while IFS= read -r f; do\n' +
+    '      [ -f "$d/$f" ] && printf "%s/%s\\n" "$d" "$f"\n' +
+    '    done\n' +
+    'done | sort -u | head -n "$lim"\n'
+
+  function rescanLibrary() { libraryScan.running = true }
+
+  Process {
+    id: libraryScan
+    command: ["timeout", "-k", "1", String(root.scanSeconds),
+              "bash", "-c", root.scanScript, "_",
+              String(root.scanLimit + 1), String(root.entryLimit)]
+    onExited: function(code) { if (code !== 0) root.videosTruncated = true }
+    stderr: StdioCollector {
+      onStreamFinished: if (String(text || "").indexOf("TRUNC") !== -1) root.videosTruncated = true
+    }
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var seen = ({})
+        var list = []
+        root.videosTruncated = false
+        var lines = String(text || "").split("\n")
+        for (var i = 0; i < lines.length; i++) {
+          var pth = root.safePath(lines[i])
+          if (pth === "" || Object.prototype.hasOwnProperty.call(seen, pth)) continue
+          if (list.length >= root.scanLimit) { root.videosTruncated = true; break }
+          seen[pth] = true
+          var slash = pth.lastIndexOf("/")
+          list.push({ path: pth, name: slash >= 0 ? pth.substring(slash + 1) : pth })
+        }
+        root.availableVideos = list
+        root.seedRotation()
+      }
+    }
+  }
+
+  // So clips dropped into ~/Videos join the rotation without opening the panel.
+  // Only while something is actually rotating: with rotation off nobody reads
+  // the library except the panel, and the panel rescans when it opens.
+  Timer {
+    interval: 300000
+    running: root.anyRotationActive
+    repeat: true
+    onTriggered: root.rescanLibrary()
+  }
+
+  // ----------------------------------------------------------- the rotation
+  // The pool of clips rotation draws from, filtered to files that are really
+  // there so a deleted clip cannot blank a monitor mid-cycle.
+  // ------------------------------------------------- per-screen profiles
+  // No entry in screenRotation means the screen follows the globals, which are
+  // what the panel edits under "All screens". An entry overrides them.
+  //
+  // Everything derived is resolved once, here, into a real property. A binding
+  // that reads `screenPlans` re-evaluates whenever any input changes -
+  // screenRotation, the globals, the library, or the file-existence maps -
+  // without anything having to remember to signal it.
+  readonly property var screenPlans: {
+    var plans = ({})
+    var sr = root.screenRotation || ({})
+    var gMode = root.rotationMode
+    var gOrder = root.rotationOrder
+    var gInterval = root.rotationInterval
+    var gList = root.playlist || []
+    var av = root.availableVideos || []
+
+    // Read explicitly so the binding depends on them: the pool below is
+    // filtered by pathExists(), which is a function call and would otherwise
+    // leave no trace for QML to track.
+    var _ex = root.existingPaths, _lib = root.libraryPaths, _st = root.statedPaths
+
+    var screens = Quickshell.screens
+    for (var i = 0; i < screens.length; i++) {
+      var n = String(screens[i].name)
+      var o = Object.prototype.hasOwnProperty.call(sr, n) ? sr[n] : null
+
+      var mode = root.safeMode(o && o.mode !== undefined ? o.mode : gMode)
+      var order = root.safeOrder(o && o.order !== undefined ? o.order : gOrder)
+      var interval = root.safeInterval(o && o.interval !== undefined ? o.interval : gInterval)
+      var list = (o && o.playlist !== undefined) ? root.normalizePlaylist(o.playlist) : gList
+
+      var pool = []
+      if (mode === "selected") {
+        for (var j = 0; j < list.length; j++)
+          if (root.pathExists(list[j])) pool.push(String(list[j]))
+      } else if (mode !== "off") {
+        for (var k = 0; k < av.length; k++) pool.push(String(av[k].path))
+      }
+
+      plans[n] = {
+        mode: mode, order: order, interval: interval,
+        playlist: list, pool: pool,
+        active: mode !== "off" && pool.length > 0,
+        own: o !== null
+      }
+    }
+    return plans
+  }
+
+  function planFor(name) {
+    var p = root.screenPlans || ({})
+    var n = String(name)
+    return Object.prototype.hasOwnProperty.call(p, n) ? p[n] : null
+  }
+
+  // Thin readers over screenPlans, kept for the IPC/status surface. A screen
+  // that is not connected has no plan, so these fall back to the globals.
+  function hasOwnProfile(name) { var p = root.planFor(name); return p ? p.own === true : false }
+  function rotModeFor(name) { var p = root.planFor(name); return p ? p.mode : root.safeMode(root.rotationMode) }
+  function rotOrderFor(name) { var p = root.planFor(name); return p ? p.order : root.safeOrder(root.rotationOrder) }
+  function rotIntervalFor(name) { var p = root.planFor(name); return p ? p.interval : root.safeInterval(root.rotationInterval) }
+  function rotPlaylistFor(name) { var p = root.planFor(name); return p ? p.playlist : (root.playlist || []) }
+  function rotationPoolFor(name) { var p = root.planFor(name); return p ? p.pool : [] }
+  function rotationActiveFor(name) { var p = root.planFor(name); return p ? p.active === true : false }
+
+  readonly property bool anyRotationActive: {
+    var p = root.screenPlans || ({})
+    for (var k in p) if (p[k].active === true) return true
+    return false
+  }
+
+  function _pickIndex(name, pool, prevIdx) {
+    if (pool.length <= 1) return 0
+    if (root.rotOrderFor(name) === "sequential")
+      return (prevIdx + 1) % pool.length
+    var n = prevIdx
+    for (var guard = 0; guard < 12 && n === prevIdx; guard++)
+      n = Math.floor(Math.random() * pool.length)
+    return n
+  }
+
+  // Idempotent: only touches a screen that has no clip yet, or whose clip has
+  // fallen out of its pool. Safe to run on every screenPlans change, which is
+  // what starts rotation the moment a pool becomes usable - the stat that fills
+  // it is async, so the mutator that set the playlist ran too early to know.
+  // Screens start at different offsets so a two-monitor setup does not open on
+  // the same clip on both.
+  function seedRotation() {
+    var plans = root.screenPlans || ({})
+    var cur = ({}), cus = ({})
+    for (var a in root.rotCurrent) cur[a] = root.rotCurrent[a]
+    for (var b in root.rotCursor) cus[b] = root.rotCursor[b]
+
+    var changed = false
+    var i = 0
+    for (var n in plans) {
+      var pl = plans[n]
+      if (!pl.active) {
+        if (cur[n] !== undefined) { delete cur[n]; delete cus[n]; changed = true }
+      } else if (cur[n] === undefined || pl.pool.indexOf(cur[n]) < 0) {
+        var idx = pl.order === "sequential"
+                ? (i % pl.pool.length)
+                : Math.floor(Math.random() * pl.pool.length)
+        cus[n] = idx
+        cur[n] = pl.pool[idx]
+        changed = true
+      }
+      i++
+    }
+    if (changed) { root.rotCursor = cus; root.rotCurrent = cur }
+  }
+
+  // Each screen keeps its own cursor, so monitors sharing a playlist still sit
+  // at different points in it.
+  function advanceRotationFor(name) {
+    var n = String(name)
+    var pl = root.planFor(n)
+    if (!pl || !pl.active) return
+    var pool = pl.pool
+    var prevCur = root.rotCursor || ({})
+    var prev = Object.prototype.hasOwnProperty.call(prevCur, n) ? Number(prevCur[n]) : -1
+    if (!isFinite(prev) || prev < 0 || prev >= pool.length) prev = 0
+    var nxt = root._pickIndex(n, pool, prev)
+
+    var cur = ({}), cus = ({})
+    for (var a in root.rotCurrent) cur[a] = root.rotCurrent[a]
+    for (var b in root.rotCursor) cus[b] = root.rotCursor[b]
+    cus[n] = nxt
+    cur[n] = pool[nxt]
+    root.rotCursor = cus
+    root.rotCurrent = cur
+  }
+
+  // "Next" with no screen advances every rotating screen.
+  function advanceRotation(name) {
+    if (name !== undefined && String(name) !== "" && String(name) !== "all") {
+      root.advanceRotationFor(name)
+      return
+    }
+    var plans = root.screenPlans || ({})
+    for (var n in plans) root.advanceRotationFor(n)
+  }
+
+  // seedRotation() is idempotent, so hanging it off screenPlans covers every
+  // input at once - the globals, per-screen overrides, the library, and the
+  // async stat that decides whether a "selected" pool is usable yet.
+  onScreenPlansChanged: root.seedRotation()
+
+  // No global rotation timer any more: each monitor's surface owns its own,
+  // running at that screen's own interval. See the Timer in the Variants
+  // delegate below.
+
   // --------------------------------------------------------- clip resolution
   // The clip CONFIGURED for a monitor — its own override if it has one,
   // otherwise the default clip when `output` targets it. "" means nothing.
@@ -235,7 +582,23 @@ Item {
   function configuredPathForScreen(name) {
     var n = String(name)
     var sv = root.screenVideos || ({})
-    if (Object.prototype.hasOwnProperty.call(sv, n)) return String(sv[n] || "")
+    var pinned = Object.prototype.hasOwnProperty.call(sv, n)
+
+    // A monitor deliberately BLANKED ("" in screenVideos) stays blank — that is
+    // the opt-out, and it is how you keep one screen out of the rotation.
+    if (pinned && String(sv[n] || "") === "") return ""
+
+    // Rotation drives every monitor the output targets, including ones with a
+    // per-monitor clip. screenVideos is never rewritten, so switching rotation
+    // off restores those assignments untouched.
+    if (root.rotationActiveFor(n) && (root.output === "all" || root.output === n)) {
+      var rc = root.rotCurrent || ({})
+      if (Object.prototype.hasOwnProperty.call(rc, n) && String(rc[n] || "") !== "")
+        return String(rc[n])
+    }
+
+    // Rotation off (or nothing seeded yet): the original behaviour, unchanged.
+    if (pinned) return String(sv[n] || "")
     if (root.output === "all" || root.output === n) return String(root.videoPath || "")
     return ""
   }
@@ -280,7 +643,12 @@ Item {
       output: root.output,
       pauseOnFullscreen: root.pauseOnFullscreen,
       screenVideos: root.screenVideos || ({}),
-      playbackSpeed: root.playbackSpeed
+      playbackSpeed: root.playbackSpeed,
+      rotationMode: root.rotationMode,
+      rotationOrder: root.rotationOrder,
+      rotationInterval: root.rotationInterval,
+      playlist: root.playlist || [],
+      screenRotation: root.screenRotation || ({})
     }, null, 2) + "\n"
     root.writeState(payload)
   }
@@ -334,6 +702,11 @@ Item {
           root._stateHadScreens = true
         }
         if (o.playbackSpeed !== undefined) root.playbackSpeed = root.safeSpeed(o.playbackSpeed)
+        if (o.rotationMode !== undefined) root.rotationMode = root.safeMode(o.rotationMode)
+        if (o.rotationOrder !== undefined) root.rotationOrder = root.safeOrder(o.rotationOrder)
+        if (o.rotationInterval !== undefined) root.rotationInterval = root.safeInterval(o.rotationInterval)
+        if (o.playlist !== undefined) root.playlist = root.normalizePlaylist(o.playlist)
+        if (o.screenRotation !== undefined) root.screenRotation = root.normalizeScreenRotation(o.screenRotation)
         return true
       }
     } catch (e) {
@@ -462,7 +835,7 @@ Item {
     onExited: stateReadProc.running = true
   }
 
-  Component.onCompleted: mkStateDir.running = true
+  Component.onCompleted: { mkStateDir.running = true; root.rescanLibrary() }
 
   // ------------------------------------------------------- fullscreen watch
   // Quickshell.Hyprland.rawEvent tells us WHEN to re-check; hyprctl gives us
@@ -564,6 +937,16 @@ Item {
       readonly property bool monFullscreen: root.pauseOnFullscreen
                                             && (root.fullscreenMonitors[monName] === true)
       readonly property bool shouldPlay: !root.manualPaused && !monFullscreen
+
+      // One timer per monitor, at that monitor's own interval. Gated on
+      // shouldPlay so a fullscreen window does not churn wallpapers behind it.
+      Timer {
+        readonly property var plan: root.screenPlans[panel.monName] || null
+        interval: plan ? plan.interval * 60000 : 600000
+        running: root.enabled && panel.shouldPlay && plan !== null && plan.active === true
+        repeat: true
+        onTriggered: root.advanceRotationFor(panel.monName)
+      }
 
       // ---- A/B double buffer ----
       // A single MediaPlayer per surface cannot change clips cleanly: assigning
@@ -742,7 +1125,13 @@ Item {
         return a
       })(),
       fullscreenMonitors: Object.keys(root.fullscreenMonitors),
-      playbackSpeed: root.playbackSpeed
+      playbackSpeed: root.playbackSpeed,
+      rotationMode: root.rotationMode,
+      rotationOrder: root.rotationOrder,
+      rotationInterval: root.rotationInterval,
+      rotationActive: root.anyRotationActive,
+      playlist: root.playlist || [],
+      libraryCount: (root.availableVideos || []).length
     }
   }
 
@@ -764,7 +1153,13 @@ Item {
         paused: root.manualPaused
                 || (root.pauseOnFullscreen && root.fullscreenMonitors[n] === true),
         playing: root.urlForScreen(n) !== "" && !root.manualPaused
-                 && !(root.pauseOnFullscreen && root.fullscreenMonitors[n] === true)
+                 && !(root.pauseOnFullscreen && root.fullscreenMonitors[n] === true),
+        rotationMode: root.rotModeFor(n),
+        rotationOrder: root.rotOrderFor(n),
+        rotationInterval: root.rotIntervalFor(n),
+        rotationActive: root.rotationActiveFor(n),
+        rotationOwnProfile: root.hasOwnProfile(n),
+        playlistCount: root.rotPlaylistFor(n).length
       })
     }
     return out
@@ -881,6 +1276,74 @@ Item {
     return root.statusObject()
   }
 
+  // A new object, so bindings reading the map actually re-evaluate.
+  function _cloneScreenRotation() {
+    var out = ({})
+    var sr = root.screenRotation || ({})
+    for (var k in sr) {
+      var e = ({})
+      for (var f in sr[k]) e[f] = sr[k][f]
+      out[k] = e
+    }
+    return out
+  }
+
+  // screen === "" or "all" edits the global defaults; a connector name edits
+  // just that monitor's profile, creating one if it had none.
+  function applySetRotation(mode, order, minutes, screen) {
+    var sc = String(screen === undefined ? "" : screen)
+    if (sc === "" || sc === "all") {
+      if (mode !== undefined && String(mode) !== "") root.rotationMode = root.safeMode(mode)
+      if (order !== undefined && String(order) !== "") root.rotationOrder = root.safeOrder(order)
+      if (minutes !== undefined && String(minutes) !== "") root.rotationInterval = root.safeInterval(minutes)
+    } else {
+      var m = root._cloneScreenRotation()
+      var e = m[sc] || ({})
+      if (mode !== undefined && String(mode) !== "") e.mode = root.safeMode(mode)
+      if (order !== undefined && String(order) !== "") e.order = root.safeOrder(order)
+      if (minutes !== undefined && String(minutes) !== "") e.interval = root.safeInterval(minutes)
+      m[sc] = e
+      root.screenRotation = m
+    }
+    root.seedRotation()
+    root.persistState()
+    return root.statusObject()
+  }
+
+  function applySetPlaylist(paths, screen) {
+    var sc = String(screen === undefined ? "" : screen)
+    if (sc === "" || sc === "all") {
+      root.playlist = root.normalizePlaylist(paths)
+    } else {
+      var m = root._cloneScreenRotation()
+      var e = m[sc] || ({})
+      e.playlist = root.normalizePlaylist(paths)
+      m[sc] = e
+      root.screenRotation = m
+    }
+    root.seedRotation()
+    root.persistState()
+    return root.statusObject()
+  }
+
+  // Drop a screen's override so it follows the global settings again.
+  function applyClearScreenRotation(screen) {
+    var sc = root.safeName(screen, "")
+    if (sc === "") return root.statusObject()
+    var m = root._cloneScreenRotation()
+    delete m[sc]
+    root.screenRotation = m
+    root.seedRotation()
+    root.persistState()
+    return root.statusObject()
+  }
+
+  // Skip ahead without waiting out the interval. No screen = every screen.
+  function applyNextVideo(screen) {
+    root.advanceRotation(screen)
+    return root.statusObject()
+  }
+
   IpcHandler {
     target: "motion-wallpaper"
 
@@ -945,6 +1408,36 @@ Item {
 
     function setSpeed(value: string): string {
       return JSON.stringify(root.applySetSpeed(value))
+    }
+
+    function setRotation(mode: string, order: string, minutes: string): string {
+      return JSON.stringify(root.applySetRotation(mode, order, minutes, ""))
+    }
+
+    // Same, aimed at one monitor: setRotationOn DP-1 all shuffle 5
+    function setRotationOn(screen: string, mode: string, order: string, minutes: string): string {
+      return JSON.stringify(root.applySetRotation(mode, order, minutes, screen))
+    }
+
+    // Drop a screen's own profile; it follows the global settings again.
+    function clearRotationOn(screen: string): string {
+      return JSON.stringify(root.applyClearScreenRotation(screen))
+    }
+
+    function setPlaylist(paths: string): string {
+      return JSON.stringify(root.applySetPlaylist(String(paths || "").split(":"), ""))
+    }
+
+    function setPlaylistOn(screen: string, paths: string): string {
+      return JSON.stringify(root.applySetPlaylist(String(paths || "").split(":"), screen))
+    }
+
+    function next(): string {
+      return JSON.stringify(root.applyNextVideo(""))
+    }
+
+    function nextOn(screen: string): string {
+      return JSON.stringify(root.applyNextVideo(screen))
     }
 
     function ping(): string { return "ok" }

--- a/Service.qml
+++ b/Service.qml
@@ -151,8 +151,10 @@ Item {
 
   // Per-monitor rotation position: each screen keeps its own cursor and clip.
   // Ephemeral - not persisted, re-seeded on start.
-  // Per-screen overrides: { "DP-1": { mode, order, interval, playlist } }.
-  // A screen with no entry follows the globals above.
+  // Per-screen overrides: { "DP-1": { mode, order, interval, playlist,
+  // speed, off, paused } }. A screen with no entry follows the globals above.
+  // The first four are rotation; speed/off/paused are that screen's own
+  // playback, so a monitor can be stopped or slowed on its own.
   property var screenRotation: ({})
 
   property var rotCurrent: ({})   // connector -> path showing right now
@@ -332,6 +334,8 @@ Item {
   // Accept only { connector: { mode, order, interval, playlist } }; every field
   // is run through the same validators as the globals, and anything unexpected
   // is dropped rather than allowed to reach the render rule.
+  function safeBool(v) { return v === true || String(v) === "true" }
+
   function normalizeScreenRotation(v) {
     var out = ({})
     if (!v || typeof v !== "object") return out
@@ -347,6 +351,9 @@ Item {
       if (o.order !== undefined) e.order = root.safeOrder(o.order)
       if (o.interval !== undefined) e.interval = root.safeInterval(o.interval)
       if (o.playlist !== undefined) e.playlist = root.normalizePlaylist(o.playlist)
+      if (o.speed !== undefined) e.speed = root.safeSpeed(o.speed)
+      if (o.off !== undefined) e.off = root.safeBool(o.off)
+      if (o.paused !== undefined) e.paused = root.safeBool(o.paused)
       out[name] = e
       n++
     }
@@ -437,6 +444,9 @@ Item {
     var gOrder = root.rotationOrder
     var gInterval = root.rotationInterval
     var gList = root.playlist || []
+    var gSpeed = root.playbackSpeed
+    var gOff = !root.enabled
+    var gPaused = root.manualPaused
     var av = root.availableVideos || []
 
     // Read explicitly so the binding depends on them: the pool below is
@@ -462,10 +472,20 @@ Item {
         for (var k = 0; k < av.length; k++) pool.push(String(av[k].path))
       }
 
+      // Playback, resolved the same way: an entry overrides, absence inherits.
+      var speed = root.safeSpeed(o && o.speed !== undefined ? o.speed : gSpeed)
+      var off = (o && o.off !== undefined) ? o.off === true : gOff
+      var paused = (o && o.paused !== undefined) ? o.paused === true : gPaused
+
       plans[n] = {
         mode: mode, order: order, interval: interval,
         playlist: list, pool: pool,
-        active: mode !== "off" && pool.length > 0,
+        active: mode !== "off" && pool.length > 0 && !off,
+        speed: speed, off: off, paused: paused,
+        // Only true when the screen sets its OWN playback, so the panel can
+        // tell "stopped because I stopped this screen" from "stopped because
+        // everything is stopped".
+        ownPlayback: !!(o && (o.speed !== undefined || o.off !== undefined || o.paused !== undefined)),
         own: o !== null
       }
     }
@@ -485,8 +505,13 @@ Item {
   function rotOrderFor(name) { var p = root.planFor(name); return p ? p.order : root.safeOrder(root.rotationOrder) }
   function rotIntervalFor(name) { var p = root.planFor(name); return p ? p.interval : root.safeInterval(root.rotationInterval) }
   function rotPlaylistFor(name) { var p = root.planFor(name); return p ? p.playlist : (root.playlist || []) }
-  function rotationPoolFor(name) { var p = root.planFor(name); return p ? p.pool : [] }
   function rotationActiveFor(name) { var p = root.planFor(name); return p ? p.active === true : false }
+
+  // Playback readers. A disconnected screen has no plan, so fall back to global.
+  function speedFor(name) { var p = root.planFor(name); return p ? p.speed : root.playbackSpeed }
+  function offFor(name) { var p = root.planFor(name); return p ? p.off === true : !root.enabled }
+  function pausedFor(name) { var p = root.planFor(name); return p ? p.paused === true : root.manualPaused }
+  function hasOwnPlayback(name) { var p = root.planFor(name); return p ? p.ownPlayback === true : false }
 
   readonly property bool anyRotationActive: {
     var p = root.screenPlans || ({})
@@ -605,7 +630,9 @@ Item {
 
   // The clip a monitor should show right now. "" means no surface.
   function pathForScreen(name) {
-    return root.enabled ? root.configuredPathForScreen(name) : ""
+    // A screen with its own `off` decides for itself; otherwise the global
+    // Stop still governs, so nothing changes for anyone not using profiles.
+    return root.offFor(name) ? "" : root.configuredPathForScreen(name)
   }
 
   // Same, as a playable url — empty unless the file is actually there.
@@ -936,14 +963,16 @@ Item {
       readonly property string monName: String(modelData.name)
       readonly property bool monFullscreen: root.pauseOnFullscreen
                                             && (root.fullscreenMonitors[monName] === true)
-      readonly property bool shouldPlay: !root.manualPaused && !monFullscreen
+      readonly property var plan: root.screenPlans[panel.monName] || null
+      readonly property bool monPaused: plan ? plan.paused === true : root.manualPaused
+      readonly property real monSpeed: plan ? plan.speed : root.playbackSpeed
+      readonly property bool shouldPlay: !monPaused && !monFullscreen
 
       // One timer per monitor, at that monitor's own interval. Gated on
       // shouldPlay so a fullscreen window does not churn wallpapers behind it.
       Timer {
-        readonly property var plan: root.screenPlans[panel.monName] || null
-        interval: plan ? plan.interval * 60000 : 600000
-        running: root.enabled && panel.shouldPlay && plan !== null && plan.active === true
+        interval: panel.plan ? panel.plan.interval * 60000 : 600000
+        running: panel.shouldPlay && panel.plan !== null && panel.plan.active === true
         repeat: true
         onTriggered: root.advanceRotationFor(panel.monName)
       }
@@ -983,7 +1012,7 @@ Item {
         id: playerA
         videoOutput: outA
         loops: MediaPlayer.Infinite
-        playbackRate: root.playbackSpeed
+        playbackRate: panel.monSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerA, err, str) }
       }
@@ -992,7 +1021,7 @@ Item {
         id: playerB
         videoOutput: outB
         loops: MediaPlayer.Infinite
-        playbackRate: root.playbackSpeed
+        playbackRate: panel.monSpeed
         audioOutput: AudioOutput { muted: true; volume: 0 }
         onErrorOccurred: function(err, str) { panel.handleError(playerB, err, str) }
       }
@@ -1150,15 +1179,18 @@ Item {
         video: p,
         source: own ? "screen" : (p === "" ? "none" : "default"),
         fileExists: p !== "" && root.pathExists(p),
-        paused: root.manualPaused
+        paused: root.pausedFor(n)
                 || (root.pauseOnFullscreen && root.fullscreenMonitors[n] === true),
-        playing: root.urlForScreen(n) !== "" && !root.manualPaused
+        playing: root.urlForScreen(n) !== "" && !root.pausedFor(n)
                  && !(root.pauseOnFullscreen && root.fullscreenMonitors[n] === true),
         rotationMode: root.rotModeFor(n),
         rotationOrder: root.rotOrderFor(n),
         rotationInterval: root.rotIntervalFor(n),
         rotationActive: root.rotationActiveFor(n),
         rotationOwnProfile: root.hasOwnProfile(n),
+        speed: root.speedFor(n),
+        off: root.offFor(n),
+        ownPlayback: root.hasOwnPlayback(n),
         playlistCount: root.rotPlaylistFor(n).length
       })
     }
@@ -1197,6 +1229,65 @@ Item {
 
   function applyPause() { root.manualPaused = true }
   function applyResume() { root.manualPaused = false }
+
+  // ---- per-screen playback -------------------------------------------------
+  // Write one field of a screen's own playback. Passing undefined clears it, so
+  // the screen goes back to following the global Play/Stop/Pause and speed.
+  function _setScreenPlayback(screen, field, value) {
+    var sc = root.safeName(screen, "")
+    if (sc === "") return root.statusObject()
+    var m = root._cloneScreenRotation()
+    var e = m[sc] || ({})
+    if (value === undefined) delete e[field]
+    else e[field] = value
+    // An entry holding nothing is the same as no entry; drop it so
+    // hasOwnProfile() stays honest.
+    var empty = true
+    for (var k in e) { empty = false; break }
+    if (empty) delete m[sc]; else m[sc] = e
+    root.screenRotation = m
+    root.persistState()
+    return root.statusObject()
+  }
+
+  function applyStopScreen(screen) { return root._setScreenPlayback(screen, "off", true) }
+  function applyPlayScreen(screen) {
+    var sc = root.safeName(screen, "")
+    if (sc === "") return root.statusObject()
+    // Playing one screen must not leave it hostage to a global Stop.
+    if (!root.enabled) { root.enabled = true; root.manualPaused = false }
+    var m = root._cloneScreenRotation()
+    var e = m[sc] || ({})
+    e.off = false
+    e.paused = false
+    m[sc] = e
+    root.screenRotation = m
+    root.persistState()
+    return root.statusObject()
+  }
+  function applyToggleScreen(screen) {
+    return root.offFor(screen) ? root.applyPlayScreen(screen)
+                               : root.applyStopScreen(screen)
+  }
+  function applyPauseScreen(screen) { return root._setScreenPlayback(screen, "paused", true) }
+  function applyResumeScreen(screen) { return root._setScreenPlayback(screen, "paused", false) }
+  function applySetSpeedOn(screen, v) { return root._setScreenPlayback(screen, "speed", root.safeSpeed(v)) }
+
+  // Drop a screen's own playback fields; rotation settings are left alone.
+  function applyClearScreenPlayback(screen) {
+    var sc = root.safeName(screen, "")
+    if (sc === "") return root.statusObject()
+    var m = root._cloneScreenRotation()
+    var e = m[sc]
+    if (!e) return root.statusObject()
+    delete e.speed; delete e.off; delete e.paused
+    var empty = true
+    for (var k in e) { empty = false; break }
+    if (empty) delete m[sc]; else m[sc] = e
+    root.screenRotation = m
+    root.persistState()
+    return root.statusObject()
+  }
 
   // Play `path` on every monitor: sets the default clip, drops every
   // per-monitor override and un-targets, so "all screens" really means all of
@@ -1438,6 +1529,34 @@ Item {
 
     function nextOn(screen: string): string {
       return JSON.stringify(root.applyNextVideo(screen))
+    }
+
+    function playOnScreen(screen: string): string {
+      return JSON.stringify(root.applyPlayScreen(screen))
+    }
+
+    function stopOnScreen(screen: string): string {
+      return JSON.stringify(root.applyStopScreen(screen))
+    }
+
+    function toggleOnScreen(screen: string): string {
+      return JSON.stringify(root.applyToggleScreen(screen))
+    }
+
+    function pauseOnScreen(screen: string): string {
+      return JSON.stringify(root.applyPauseScreen(screen))
+    }
+
+    function resumeOnScreen(screen: string): string {
+      return JSON.stringify(root.applyResumeScreen(screen))
+    }
+
+    function setSpeedOn(screen: string, value: string): string {
+      return JSON.stringify(root.applySetSpeedOn(screen, value))
+    }
+
+    function followGlobalPlayback(screen: string): string {
+      return JSON.stringify(root.applyClearScreenPlayback(screen))
     }
 
     function ping(): string { return "ok" }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.4.0",
   "author": "Gavin Nugent",
   "license": "MIT",
-  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, adjustable playback speed, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
+  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, adjustable playback speed, optional rotation through your library on a per-monitor schedule, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
   "kinds": ["service", "bar-widget"],
   "entryPoints": {
     "service": "Service.qml",

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "id": "nosignal.motion-wallpaper",
   "name": "Motion Wallpaper",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "author": "Gavin Nugent",
   "license": "MIT",
-  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
+  "description": "Native looping video wallpaper for omarchy-shell. Renders a muted, looping video on the background layer above the static wallpaper, with a different clip per monitor if you want one, adjustable playback speed, and auto-pause on fullscreen. Controlled from its bar widget, or from a terminal with the motion-wallpaper CLI.",
   "kinds": ["service", "bar-widget"],
   "entryPoints": {
     "service": "Service.qml",

--- a/motion-wallpaper
+++ b/motion-wallpaper
@@ -222,6 +222,59 @@ cmd_speed() {
   ipc setSpeed "$v" >/dev/null
 }
 
+# rotate <off|all|selected> [shuffle|order] [minutes] [screen]
+cmd_rotate() {
+  require_plugin
+  local mode="${1:-}" order="${2:-}" mins="${3:-}" screen="${4:-}"
+  case "$mode" in
+    off|all|selected) ;;
+    *) err "usage: motion-wallpaper rotate <off|all|selected> [shuffle|order] [minutes] [screen]"; exit 1 ;;
+  esac
+  case "$order" in
+    ""|shuffle) order=shuffle ;;
+    order|sequential) order=sequential ;;
+    *) err "order must be 'shuffle' or 'order'"; exit 1 ;;
+  esac
+  if [ -n "$screen" ] && [ "$screen" != "all" ]; then
+    ipc setRotationOn "$screen" "$mode" "$order" "$mins" >/dev/null
+  else
+    ipc setRotation "$mode" "$order" "$mins" >/dev/null
+  fi
+}
+
+# playlist <screen|all> <file...>
+cmd_playlist() {
+  require_plugin
+  local screen="${1:-}"; shift || true
+  [ -n "$screen" ] || { err "usage: motion-wallpaper playlist <screen|all> <file>..."; exit 1; }
+  [ "$#" -gt 0 ] || { err "usage: motion-wallpaper playlist <screen|all> <file>..."; exit 1; }
+  local joined="" f p
+  for f in "$@"; do
+    p="$(readlink -f "$f")" || { err "no such file: $f"; exit 1; }
+    [ -f "$p" ] || { err "no such file: $f"; exit 1; }
+    joined="${joined:+$joined:}$p"
+  done
+  if [ "$screen" = "all" ]; then
+    ipc setPlaylist "$joined" >/dev/null
+  else
+    ipc setPlaylistOn "$screen" "$joined" >/dev/null
+  fi
+}
+
+cmd_next() {
+  require_plugin
+  local s="${1:-}"
+  if [ -n "$s" ] && [ "$s" != "all" ]; then ipc nextOn "$s" >/dev/null
+  else ipc next >/dev/null; fi
+}
+
+cmd_follow() {
+  require_plugin
+  local s="${1:-}"
+  [ -n "$s" ] || { err "usage: motion-wallpaper follow <screen>"; exit 1; }
+  ipc clearRotationOn "$s" >/dev/null
+}
+
 case "${1:-status}" in
   status|"") cmd_status ;;
   screens)   cmd_screens ;;
@@ -235,6 +288,10 @@ case "${1:-status}" in
   screen)    shift; cmd_screen "${1:-}" ;;
   autopause) shift; cmd_autopause "${1:-}" ;;
   speed)     shift; cmd_speed "${1:-}" ;;
+  rotate)    shift; cmd_rotate "${1:-}" "${2:-}" "${3:-}" "${4:-}" ;;
+  playlist)  shift; cmd_playlist "$@" ;;
+  next)      shift; cmd_next "${1:-}" ;;
+  follow)    shift; cmd_follow "${1:-}" ;;
   -h|--help)
     cat <<USAGE
 $APP_NAME — control the omarchy-shell video wallpaper plugin.
@@ -252,6 +309,16 @@ Usage: ${0##*/} [command]
   screen <name|all>     Coarse targeting for monitors with no clip of their own.
   autopause <on|off>    Pause video under fullscreen windows.
   speed <0.25-2>        Playback speed, e.g. 1, 0.5, 0.66.
+
+Rotation (off by default — one clip until you turn it on):
+  rotate <off|all|selected> [shuffle|order] [minutes] [screen]
+  playlist <screen|all> <file>...   Clips for "selected" mode.
+  next [screen]         Skip ahead without waiting out the interval.
+  follow <screen>       Drop a screen's own settings; follow the default.
+
+Each screen can rotate differently — shuffle on one, fixed on the other:
+  ${0##*/} rotate all shuffle 5 DP-1
+  ${0##*/} rotate off "" "" DP-2
 
 Different clips on different screens:
   ${0##*/} play ~/Videos/a.mp4 DP-1

--- a/motion-wallpaper
+++ b/motion-wallpaper
@@ -213,6 +213,15 @@ cmd_autopause() {
   esac
 }
 
+cmd_speed() {
+  require_plugin
+  local v="${1:-}"
+  case "$v" in
+    ""|*[!0-9.]*|*.*.*) err "usage: motion-wallpaper speed <0.25-2>"; exit 1 ;;
+  esac
+  ipc setSpeed "$v" >/dev/null
+}
+
 case "${1:-status}" in
   status|"") cmd_status ;;
   screens)   cmd_screens ;;
@@ -225,6 +234,7 @@ case "${1:-status}" in
   resume)    require_plugin; ipc resume >/dev/null ;;
   screen)    shift; cmd_screen "${1:-}" ;;
   autopause) shift; cmd_autopause "${1:-}" ;;
+  speed)     shift; cmd_speed "${1:-}" ;;
   -h|--help)
     cat <<USAGE
 $APP_NAME — control the omarchy-shell video wallpaper plugin.
@@ -241,6 +251,7 @@ Usage: ${0##*/} [command]
   pause | resume        Pause/resume playback.
   screen <name|all>     Coarse targeting for monitors with no clip of their own.
   autopause <on|off>    Pause video under fullscreen windows.
+  speed <0.25-2>        Playback speed, e.g. 1, 0.5, 0.66.
 
 Different clips on different screens:
   ${0##*/} play ~/Videos/a.mp4 DP-1

--- a/motion-wallpaper
+++ b/motion-wallpaper
@@ -169,9 +169,20 @@ cmd_screens() {
 
 # play <file> [screen] — no screen means every monitor (and drops any
 # per-monitor clips); with a screen, only that monitor changes.
+is_screen() {
+  local n="${1:-}"
+  [ -n "$n" ] || return 1
+  ipc status 2>/dev/null | jq -e --arg n "$n" '(.screens // [])[] | select(.name == $n)' >/dev/null 2>&1
+}
+
 cmd_play() {
   require_plugin
   local f="${1:-}" s="${2:-}"
+  # `play DP-1` (a monitor, no file) restarts that screen after `stop DP-1`.
+  if [ -z "$s" ] && is_screen "$f"; then
+    ipc playOnScreen "$f" >/dev/null
+    return
+  fi
   [ -n "$f" ] || { err "usage: motion-wallpaper play <file> [screen]"; exit 1; }
   [ -f "$f" ] || { err "file not found: $f"; exit 1; }
   local p; p="$(readlink -f "$f")"
@@ -215,11 +226,34 @@ cmd_autopause() {
 
 cmd_speed() {
   require_plugin
-  local v="${1:-}"
+  local v="${1:-}" s="${2:-}"
   case "$v" in
-    ""|*[!0-9.]*|*.*.*) err "usage: motion-wallpaper speed <0.25-2>"; exit 1 ;;
+    ""|*[!0-9.]*|*.*.*) err "usage: motion-wallpaper speed <0.25-2> [screen]"; exit 1 ;;
   esac
-  ipc setSpeed "$v" >/dev/null
+  if [ -n "$s" ] && [ "$s" != "all" ]; then ipc setSpeedOn "$s" "$v" >/dev/null
+  else ipc setSpeed "$v" >/dev/null; fi
+}
+
+# Play/stop/pause/resume, optionally for one monitor. Without a screen these are
+# the global controls they always were.
+cmd_transport() {
+  require_plugin
+  local verb="$1" s="${2:-}"
+  if [ -z "$s" ] || [ "$s" = "all" ]; then
+    case "$verb" in
+      stop)   ipc stop     >/dev/null ;;
+      toggle) ipc toggle   >/dev/null ;;
+      pause)  ipc pause    >/dev/null ;;
+      resume) ipc resume   >/dev/null ;;
+    esac
+    return
+  fi
+  case "$verb" in
+    stop)   ipc stopOnScreen   "$s" >/dev/null ;;
+    toggle) ipc toggleOnScreen "$s" >/dev/null ;;
+    pause)  ipc pauseOnScreen  "$s" >/dev/null ;;
+    resume) ipc resumeOnScreen "$s" >/dev/null ;;
+  esac
 }
 
 # rotate <off|all|selected> [shuffle|order] [minutes] [screen]
@@ -268,11 +302,18 @@ cmd_next() {
   else ipc next >/dev/null; fi
 }
 
+# Drop a screen's own settings so it follows the shared default again.
 cmd_follow() {
   require_plugin
-  local s="${1:-}"
-  [ -n "$s" ] || { err "usage: motion-wallpaper follow <screen>"; exit 1; }
-  ipc clearRotationOn "$s" >/dev/null
+  local s="${1:-}" what="${2:-all}"
+  [ -n "$s" ] || { err "usage: motion-wallpaper follow <screen> [rotation|playback|all]"; exit 1; }
+  case "$what" in
+    rotation) ipc clearRotationOn "$s" >/dev/null ;;
+    playback) ipc followGlobalPlayback "$s" >/dev/null ;;
+    all)      ipc clearRotationOn "$s" >/dev/null
+              ipc followGlobalPlayback "$s" >/dev/null ;;
+    *) err "follow: expected rotation, playback or all"; exit 1 ;;
+  esac
 }
 
 case "${1:-status}" in
@@ -281,17 +322,17 @@ case "${1:-status}" in
   play)      shift; cmd_play "${1:-}" "${2:-}" ;;
   off)       shift; cmd_off "${1:-}" ;;
   clear)     shift; cmd_clear "${1:-}" ;;
-  stop)      require_plugin; ipc stop   >/dev/null ;;
-  toggle)    require_plugin; ipc toggle >/dev/null ;;
-  pause)     require_plugin; ipc pause  >/dev/null ;;
-  resume)    require_plugin; ipc resume >/dev/null ;;
+  stop)      shift; cmd_transport stop   "${1:-}" ;;
+  toggle)    shift; cmd_transport toggle "${1:-}" ;;
+  pause)     shift; cmd_transport pause  "${1:-}" ;;
+  resume)    shift; cmd_transport resume "${1:-}" ;;
   screen)    shift; cmd_screen "${1:-}" ;;
   autopause) shift; cmd_autopause "${1:-}" ;;
-  speed)     shift; cmd_speed "${1:-}" ;;
+  speed)     shift; cmd_speed "${1:-}" "${2:-}" ;;
   rotate)    shift; cmd_rotate "${1:-}" "${2:-}" "${3:-}" "${4:-}" ;;
   playlist)  shift; cmd_playlist "$@" ;;
   next)      shift; cmd_next "${1:-}" ;;
-  follow)    shift; cmd_follow "${1:-}" ;;
+  follow)    shift; cmd_follow "${1:-}" "${2:-}" ;;
   -h|--help)
     cat <<USAGE
 $APP_NAME — control the omarchy-shell video wallpaper plugin.
@@ -301,20 +342,27 @@ Usage: ${0##*/} [command]
   status                Print current state, per monitor (default).
   screens               List each monitor and the clip it is showing.
   play <file> [screen]  Start a video everywhere, or on one monitor.
+  play <screen>         Restart one monitor after `stop <screen>`.
   off <screen>          Blank one monitor; the others keep playing.
   clear <screen|all>    Drop a monitor's own clip; follow the default again.
-  stop                  Stop; static wallpaper shows through.
-  toggle                Flip on/off (good for a keybind).
-  pause | resume        Pause/resume playback.
+  stop [screen]         Stop everywhere, or blank one monitor.
+  toggle [screen]       Flip on/off (good for a keybind).
+  pause | resume [screen]   Pause/resume, everywhere or on one monitor.
   screen <name|all>     Coarse targeting for monitors with no clip of their own.
   autopause <on|off>    Pause video under fullscreen windows.
-  speed <0.25-2>        Playback speed, e.g. 1, 0.5, 0.66.
+  speed <0.25-2> [screen]   Playback speed, e.g. 1, 0.5, 0.66.
 
 Rotation (off by default — one clip until you turn it on):
   rotate <off|all|selected> [shuffle|order] [minutes] [screen]
   playlist <screen|all> <file>...   Clips for "selected" mode.
   next [screen]         Skip ahead without waiting out the interval.
-  follow <screen>       Drop a screen's own settings; follow the default.
+  follow <screen> [rotation|playback|all]
+                        Drop a screen's own settings; follow the default.
+
+Each screen has its own profile — rotation, speed and Play/Stop:
+  ${0##*/} stop DP-2                 # DP-1 keeps playing
+  ${0##*/} speed 0.5 DP-1            # just that monitor
+  ${0##*/} follow DP-1               # back to the shared default
 
 Each screen can rotate differently — shuffle on one, fixed on the other:
   ${0##*/} rotate all shuffle 5 DP-1


### PR DESCRIPTION
Follow-up to #6, and the answer to the question I left at the end of #4. Stacked on the rotation branch, so it'll show those commits too until #6 lands.

Clips and rotation are per-monitor but playback isn't, so you can't stop or slow one screen while the other keeps going. This puts `speed`, `off` and `paused` in the same per-screen entry, resolved the same way: an entry overrides, no entry inherits the global. A screen with no profile behaves exactly as it does today.

- `pathForScreen()` checks `offFor(name)` instead of the global `enabled`, so a screen with its own `off` decides for itself and the rest still obey the global Stop
- each surface reads its own `paused`/`speed` off its plan, so `playbackRate` is per monitor
- `applyPlayScreen()` clears a global Stop first, otherwise the screen turns itself on and still renders nothing
- writing `undefined` removes a field, and an entry left holding nothing is deleted, so `hasOwnProfile()` doesn't report a profile that says nothing

Panel: the transport buttons and speed slider follow the SCREEN dropdown like the clip list already did, and the header reads the scoped state so a screen stopped on its own doesn't say "Playing".

`screensDiffer` also counts a screen with its own profile now. Without that, a screen stopped or slowed but showing the same clip looked identical, so the panel opened on *All screens* and the difference was invisible.

CLI: `stop`/`toggle`/`pause`/`resume`/`speed` take an optional screen, `play <screen>` restarts one after `stop <screen>`, and `follow <screen>` drops its profile.

Two things worth saying:

I ran a UI pass over the whole panel before opening this and it turned up three of my own bugs, all fixed here: seven CLI commands that had IPC but were never wired up, the header reading global flags, and the `screensDiffer` gap above.

There's no button to reset a screen from the panel. There was one, but it only appeared once a screen had a profile, so switching rotation on made a button materialise next to an unrelated control. It's `follow <screen>` in the CLI instead. Happy to put it back somewhere calmer if you'd rather have it.

Entirely fine if you'd rather speed stayed global and this stays on my fork - say the word and I'll close it.

MIT is fine by me.

Written with Claude as a pair-programming assistant; the commits carry a Co-Authored-By trailer. I've reviewed and tested it.
